### PR TITLE
Extract out events form.

### DIFF
--- a/features/pages/edit_event_page.rb
+++ b/features/pages/edit_event_page.rb
@@ -1,23 +1,7 @@
-class EditEventPage
-  include Capybara::DSL
-  include Capybara::Node::Matchers
-  include RSpec::Matchers
+require_relative 'event_form'
 
-  def initialize(name = nil, location = nil, takes_place_on = nil)
-    @name = name
-    @location = location
-    @takes_place_on = takes_place_on
-  end
-
+class EditEventPage < EventForm
   def update
-    fill_in "Name", with: name
-    fill_in "Location", with: location
-    fill_in "Takes place on", with: takes_place_on
-
-    click_button "Update"
+    complete("Update", attributes)
   end
-
-  private
-
-  attr_reader :location, :name, :takes_place_on
 end

--- a/features/pages/event_form.rb
+++ b/features/pages/event_form.rb
@@ -1,0 +1,19 @@
+class EventForm
+  include Capybara::DSL
+
+  def initialize(attributes = {})
+    @attributes = attributes
+  end
+
+  def complete(action, attributes)
+    fill_in "Name", with: attributes[:name]
+    fill_in "Location", with: attributes[:location]
+    fill_in "Takes place on", with: attributes[:takes_place_on]
+
+    click_button action
+  end
+
+  private
+
+  attr_reader :attributes
+end

--- a/features/pages/new_events_page.rb
+++ b/features/pages/new_events_page.rb
@@ -1,22 +1,7 @@
-class NewEventsPage
-  include Capybara::DSL
-  include Capybara::Node::Matchers
-  include RSpec::Matchers
+require_relative "event_form"
 
-  def initialize(name = nil, location = nil, takes_place_on = nil)
-    @name = name
-    @location = location
-    @takes_place_on = takes_place_on
-  end
-
+class NewEventsPage < EventForm
   def create
-    fill_in "Name", with: name
-    fill_in "Location", with: location
-    fill_in "Takes place on", with: takes_place_on
-    click_button "Create Event"
+    complete("Create Event", attributes)
   end
-
-  private
-
-  attr_reader :name, :location, :takes_place_on
 end

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -18,9 +18,9 @@ end
 
 When(/^I create a valid event$/) do
   new_event_page = NewEventsPage.new(
-    "Macclesfield Farmers Market",
-    "Town Hall, Macclesfield",
-    "25/08/2013"
+    name: "Macclesfield Farmers Market",
+    location: "Town Hall, Macclesfield",
+    takes_place_on: "25/08/2013"
   )
 
   visit new_event_path
@@ -77,9 +77,9 @@ end
 When(/^I update the event with valid data$/) do
   event = Event.first
   edit_event_page = EditEventPage.new(
-    "Macclesfield Farmers Market",
-    "Town Hall, Macclesfield",
-    "25/08/2013"
+    name: "Macclesfield Farmers Market",
+    location: "Town Hall, Macclesfield",
+    takes_place_on: "25/08/2013"
   )
 
   visit edit_event_path(event)


### PR DESCRIPTION
https://trello.com/c/DdT2Wd0l

The register method in the new event and edit event page object models were
almost identical, which was causing duplication in the code. The form actions
have been extracted out into a separate module and included in both page
object models.
