### PR TITLE
Add products to the homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ doc/
 config/heroku.yml
 /.env
 /coverage/
+/.foreman

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,12 @@ gem 'geocoder'
 gem 'draper'
 gem 'friendly_id'
 gem 'jquery-rails'
+gem 'kaminari'
 gem 'newrelic_rpm'
 gem 'paperclip'
 gem 'pg'
 gem 'rails', '~> 3'
+gem 'recipient_interceptor'
 gem 'unicorn'
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.0)
+    kaminari (0.15.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.8.0)
     launchy (2.3.0)
       addressable (~> 2.3)
@@ -135,7 +138,7 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    pg (0.16.0)
+    pg (0.17.0)
     polyglot (0.3.3)
     rack (1.4.5)
     rack-cache (1.2)
@@ -165,6 +168,8 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    recipient_interceptor (0.1.2)
+      mail
     request_store (1.0.5)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -257,12 +262,14 @@ DEPENDENCIES
   fuubar
   geocoder
   jquery-rails
+  kaminari
   launchy
   newrelic_rpm
   paperclip
   pg
   rails (~> 3)
   rails-footnotes
+  recipient_interceptor
   rspec-rails
   sass-rails
   shoulda

--- a/app/assets/stylesheets/pagination.css.scss
+++ b/app/assets/stylesheets/pagination.css.scss
@@ -1,0 +1,19 @@
+.pagination {
+  border-top: 1px solid;
+  display: block;
+  float: left;
+  font: bold 16px/16px Georgia;
+  height: 60px;
+  margin: 40px 0 0;
+  padding: 20px 0;
+  text-align: center;
+  width: 100%;
+
+  a:link, a:visited {
+    color: #5a006d;
+  }
+
+  span {
+    margin-right: 10px;
+  }
+}

--- a/app/assets/stylesheets/product_thumbnails.css.scss
+++ b/app/assets/stylesheets/product_thumbnails.css.scss
@@ -20,8 +20,7 @@
   }
 
   h3 {
-    font-family: "Open Sans", sans-serif;
-    line-height: 1.3em;
+    font: 16px/24px "Open Sans", sans-serif;
     text-align: center;
   }
 

--- a/app/assets/stylesheets/radfords.css.scss
+++ b/app/assets/stylesheets/radfords.css.scss
@@ -76,13 +76,24 @@ h2 {
 }
 
 .section {
-    display: block;
+  display: block;
+  float: left;
+  margin-top: 40px;
 }
 
 .article {
-    float: left;
-    margin-right: 10px;
-    width: 470px;
+  float: left;
+  margin-right: 70px;
+  margin-top: 10px;
+  width: 440px;
+
+  h2 {
+    font-family: 'Open Sans', sans-serif;
+  }
+
+  p {
+    font: 14px/22px Georgia, serif;
+  }
 }
 
 .last {
@@ -287,6 +298,7 @@ div.suppliers img {
 
 .footer {
     border-top: 2px solid #5A006D;
+    font-family: Georgia, serif;
     float: left;
     line-height: 36px;
     margin-top: 16px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,14 @@ class ApplicationController < ActionController::Base
   def authenticate
     deny_access unless signed_in?
   end
+
+  private
+
+  def current_basket
+    Basket.find(session[:basket_id])
+  rescue ActiveRecord::RecordNotFound
+    basket = Basket.create
+    session[:basket_id] = basket.id
+    basket
+  end
 end

--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -1,0 +1,16 @@
+class BasketsController < ApplicationController
+  skip_before_filter :authenticate
+
+  def show
+    @basket = Basket.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to shop_url, alert: t('baskets.show.alert')
+  end
+
+  def destroy
+    @basket = current_basket
+    @basket.destroy
+    session[:basket_id] = nil
+    redirect_to shop_url, notice: t('baskets.destroy.notice')
+  end
+end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -1,0 +1,19 @@
+class LineItemsController < ApplicationController
+  skip_before_filter :authenticate
+
+  def create
+    @basket = current_basket
+    @basket.add_product(product.id).save
+    redirect_to @basket
+  end
+
+  private
+
+  def product
+    Product.find(product_id)
+  end
+
+  def product_id
+    params[:product_id]
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,27 @@
+class OrdersController < ApplicationController
+  skip_before_filter :authenticate
+
+  def new
+    if current_basket.line_items.empty?
+      redirect_to(shop_url, notice: t('orders.new.notice'))
+      return
+    end
+
+    @order = Order.new
+  end
+
+  def create
+    @order = Order.new(params[:order])
+    @order.add_line_items_from_basket(current_basket)
+
+    if @order.save
+      Basket.destroy(session[:basket_id])
+      session[:basket_id] = nil
+      Rails.logger.error "#{'*' * 10} [order] #{@order.inspect}"
+      Mailer.order_received(@order).deliver
+      redirect_to shop_url, notice: 'Thank you for your order.'
+    else
+      render action: "new"
+    end
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,8 +2,8 @@ class PagesController < ApplicationController
   skip_before_filter :authenticate
 
   def home
-    @title = "Home"
-    @events = Event.find(:all, limit: 3 )
+    @events = Event.find(:all, limit: 3)
+    @products = Product.page(params[:page])
   end
 
   def products

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,9 +14,18 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    product = Product.find(params[:id])
-    product.destroy
-    redirect_to products_url, notice: 'Product was deleted.'
+    begin
+      @product = Product.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to products_url, alert: t('products.destroy.alert')
+      return
+    end
+
+    if @product.destroy
+      redirect_to products_url, notice: t('products.destroy.notice')
+    else
+      render :delete
+    end
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,10 +24,4 @@ module ApplicationHelper
       render(partial: "shared/navbar")
     end
   end
-
-  def sign_in_link
-    unless signed_in?
-      render "layouts/sign_in_link"
-    end
-  end
 end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,0 +1,7 @@
+class Mailer < ActionMailer::Base
+  def order_received(order)
+    @order = order
+
+    mail(from: 'noreply@example.com', to: order.email, subject: t('.subject'))
+  end
+end

--- a/app/models/basket.rb
+++ b/app/models/basket.rb
@@ -1,0 +1,19 @@
+class Basket < ActiveRecord::Base
+  has_many :line_items, dependent: :destroy
+
+  def add_product(product_id)
+    current_item = line_items.find_by_product_id(product_id)
+
+    if current_item
+      current_item.quantity += 1
+    else
+      current_item = line_items.build(product_id: product_id)
+    end
+
+    current_item
+  end
+
+  def total_price
+    line_items.to_a.sum {|item| item.total_price}
+  end
+end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,0 +1,9 @@
+class LineItem < ActiveRecord::Base
+  belongs_to :basket
+  belongs_to :order
+  belongs_to :product
+
+  def total_price
+    product.price * quantity
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,15 @@
+class Order < ActiveRecord::Base
+  has_many :line_items, dependent: :destroy
+
+  PAYMENT_TYPES = ['Check', 'Credit card', 'Purchase order']
+
+  validates :name, :address, :email, presence: true
+  validates :pay_type, inclusion: PAYMENT_TYPES
+
+  def add_line_items_from_basket(basket)
+    basket.line_items.each do |item|
+      item.basket_id = nil
+      line_items << item
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,9 @@
 class Product < ActiveRecord::Base
   extend FriendlyId
 
-  attr_accessible :description, :photo, :photo_file_name, :title
+  has_many :line_items
+
+  attr_accessible :description, :photo, :photo_file_name, :price, :title
 
   has_attached_file :photo,
     default_url: "/photos/original/missing_:style.png",
@@ -18,4 +20,17 @@ class Product < ActiveRecord::Base
   validates_uniqueness_of :title
 
   friendly_id :title, use: :slugged
+
+  before_destroy :ensure_not_referenced_by_any_line_item
+
+  private
+
+  def ensure_not_referenced_by_any_line_item
+    if line_items.empty?
+      return true
+    else
+      errors.add(:base, 'Line Items present')
+      return false
+    end
+  end
 end

--- a/app/views/baskets/show.html.erb
+++ b/app/views/baskets/show.html.erb
@@ -1,0 +1,30 @@
+<%= content_for(:title, t('.title')) %>
+
+<h2><%= t('.heading') %></h2>
+
+<table>
+  <% @basket.line_items.each do |item| %>
+    <tr>
+      <td><%= item.quantity %> &times;</td>
+
+      <td><%= item.product.title %></td>
+
+      <td class="item-price"><%= number_to_currency(item.total_price) %></td>
+    </tr>
+  <% end %>
+
+  <tr class="total-line">
+    <td colspan="2">Total</td>
+
+    <td class="total-cell"><%= number_to_currency(@basket.total_price) %></td>
+  </tr>
+</table>
+
+<%= button_to(t('.checkout'), new_order_path, method: :get) %>
+
+<%= button_to(
+  t('.empty_basket'),
+  @basket,
+  method: :delete,
+  confirm: t('.confirm')
+) %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,7 +1,5 @@
 <div class="footer">
   <ul>
-    <%= sign_in_link %>
-
     <li>
       <a href="mailto:radfords@hotmail.co.uk">Contact us</a>
     </li>

--- a/app/views/line_items/_line_item.text.erb
+++ b/app/views/line_items/_line_item.text.erb
@@ -1,0 +1,5 @@
+<%= sprintf(
+  '%2d x %s',
+  line_item.quantity,
+  line_item.product.title
+) %>

--- a/app/views/mailer/order_received.text.erb
+++ b/app/views/mailer/order_received.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @order.name %>
+
+Thank you for your recent order from The Pragmatic Store.
+
+You ordered the following items:
+
+<%= render(@order.line_items) %>
+
+We'll send you a separate email when your order ships.

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_for(@order, html: { class: 'form-horizontal' }) do |f| %>
+  <%= render('shared/error_messages', object: f.object) %>
+
+  <div class="control-group">
+    <%= f.label(:name, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_field(:name, class: 'text-field') %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:address, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_area(:address, class: 'text-area') %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:email, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.email_field(:email, class: 'email-field') %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:pay_type, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.select(
+        :pay_type,
+        Order::PAYMENT_TYPES,
+        'class' => 'select',
+        'prompt' => 'Select a payment method'
+      ) %>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit(nil, 'class' => 'btn btn-primary') %>
+  </div>
+<% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title, t('.title')) %>
+
+<div>
+  <fieldset>
+    <legend>Please enter your details</legend>
+
+    <%= render 'form' %>
+  </fieldset>
+</div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,15 @@
+<% content_for(:title, t('.title')) %>
+
+<ul class="product-thumbnails">
+  <%= render(
+    partial: 'product_thumbnails',
+    collection: @products,
+    as: :product
+  ) %>
+</ul>
+
+<%= paginate @products %>
+
 <div class="section">
   <div class="article">
     <h2>

--- a/app/views/products/delete.html.erb
+++ b/app/views/products/delete.html.erb
@@ -5,6 +5,8 @@
 </div>
 
 <%= form_for @product, html: { method: :delete } do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+
   <p>Are you sure you want to delete this product?</p>
 
   <div class="form-actions">

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,87 @@
+Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])
+require Rails.root.join('config/initializers/smtp')
+Radfords::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both thread web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Disable Rails's static asset server (Apache or nginx will already do this).
+  config.serve_static_assets = false
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  # Version of your assets, change this if you want to expire all your assets.
+  config.assets.version = '1.0'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Set to :debug to see everything in the log.
+  config.log_level = :info
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Precompile additional assets.
+  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+  # config.assets.precompile += %w( search.js )
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation can not be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Disable automatic flushing of the log to improve performance.
+  # config.autoflush_log = false
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  config.action_mailer.default_url_options = { host: 'staging.radfordsofsomerford.co.uk' }
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,3 @@
+Kaminari.configure do |config|
+  config.default_per_page = 8
+end

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,0 +1,10 @@
+if Rails.env.staging? || Rails.env.production?
+  SMTP_SETTINGS = {
+    address: ENV['SMTP_ADDRESS'],
+    authentication: :plain,
+    domain: ENV['SMTP_DOMAIN'],
+    password: ENV['SMTP_PASSWORD'],
+    port: 587,
+    user_name: ENV['SMTP_USERNAME']
+  }
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,32 @@
 en:
+  baskets:
+    destroy:
+      notice: Your basket is currently empty.
+    show:
+      alert: Invalid basket.
+      checkout: Checkout
+      confirm: Are you sure?
+      empty_basket: Empty basket
+      heading: Your Basket
+      title: Basket
   error_text: 'Oh snap'
   events:
     not_found: "We couldn't find the event you were looking for."
   info_text: 'Heads up'
+  orders:
+    new:
+      notice: Your basket is empty.
+      title: New order
+  pages:
+    home:
+      title: Home
+    product_thumbnails:
+      add_to_basket: Add to Basket
   products:
     create: "You successfully created a product."
+    destroy:
+      alert: "We couldn't find that product."
+      notice: Product was deleted.
   sessions:
     unauthenticated: "You need to sign in or sign up before continuing."
   success_text: 'Well done'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 Radfords::Application.routes.draw do
+  resources :orders
+  resources :baskets
   resources :events do
     member do
       get :delete
       delete :delete, action: :destroy
     end
   end
+  resources :line_items
   resources :products do
     member { get :delete }
   end
@@ -20,61 +23,4 @@ Radfords::Application.routes.draw do
   match '/shop', :to => 'pages#products'
   match '/signin',   :to => 'sessions#new'
   match '/signout',  :to => 'sessions#destroy'
-
-  # The priority is based upon order of creation:
-  # first created -> highest priority.
-
-  # Sample of regular route:
-  #   match 'products/:id' => 'catalog#view'
-  # Keep in mind you can assign values other than :controller and :action
-
-  # Sample of named route:
-  #   match 'products/:id/purchase' => 'catalog#purchase', :as => :purchase
-  # This route can be invoked with purchase_url(:id => product.id)
-
-  # Sample resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Sample resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Sample resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Sample resource route with more complex sub-resources
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', :on => :collection
-  #     end
-  #   end
-
-  # Sample resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
-
-  # You can have the root of your site routed with "root"
-  # just remember to delete public/index.html.
-  # root :to => "welcome#index"
-
-  # See how all your routes lay out with "rake routes"
-
-  # This is a legacy wild controller route that's not recommended for RESTful applications.
-  # Note: This route will make all actions in every controller accessible via GET requests.
-  # match ':controller(/:action(/:id(.:format)))'
 end

--- a/db/migrate/20131115183353_drop_orders.rb
+++ b/db/migrate/20131115183353_drop_orders.rb
@@ -1,0 +1,14 @@
+class DropOrders < ActiveRecord::Migration
+  def self.up
+    drop_table :orders
+  end
+
+  def self.down
+    create_table :orders do |t|
+      t.string :name
+      t.text :address
+      t.string :email
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20131115183444_create_orders.rb
+++ b/db/migrate/20131115183444_create_orders.rb
@@ -1,0 +1,12 @@
+class CreateOrders < ActiveRecord::Migration
+  def change
+    create_table :orders do |t|
+      t.string :name
+      t.text :address
+      t.string :email
+      t.string :pay_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121007202315) do
+ActiveRecord::Schema.define(:version => 20131115183444) do
 
   create_table "baskets", :force => true do |t|
     t.datetime "created_at", :null => false
@@ -35,10 +35,13 @@ ActiveRecord::Schema.define(:version => 20121007202315) do
     t.integer  "order_id"
   end
 
+  add_index "line_items", ["basket_id"], :name => "index_line_items_on_basket_id"
+
   create_table "orders", :force => true do |t|
     t.string   "name"
     t.text     "address"
     t.string   "email"
+    t.string   "pay_type"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -1,0 +1,22 @@
+Feature: Baskets
+
+  Scenario:
+    Given I don't have a basket
+    When I view the basket
+    Then I see the "Shop" page
+    And I see an "Invalid basket" alert
+
+    #  Scenario:
+    #    Given a product exists
+    #    And I have the product in my basket
+    #    When I empty my basket
+    #    Then I see the "Shop" page
+    #    And I see a "Your basket is currently empty" notice
+
+    #  Scenario:
+    #    Given a product exists
+    #    And I have the product in my basket
+    #    And I am on the "Shop" page
+    #    When I add the product to my basket
+    #    Then I see the "Basket" page
+    #    And I see the product in my basket twice

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -1,0 +1,29 @@
+Feature: Orders
+
+    #  Scenario:
+    #    Given a product exists
+    #    And I have the product in my basket
+    #    When I checkout my basket
+    #    Then I see the "New order" page
+
+  Scenario:
+    Given I have an empty basket
+    When I visit the "New order" page
+    Then I see the "Shop" page
+    And I see a "Your basket is empty" notice
+
+    #  Scenario:
+    #    Given a product exists
+    #    And I have the product in my basket
+    #    And I have checked out my basket
+    #    When I create the order
+    #    Then I see the "Shop" page
+    #    And I see a "Thank you for your order" notice
+
+    #  Scenario:
+    #    Given a product exists
+    #    And I have the product in my basket
+    #    And I have checked out my basket
+    #    When I create the order incorrectly
+    #    Then I see the "New order" page
+    #    And I see some validation messages

--- a/features/products.feature
+++ b/features/products.feature
@@ -4,3 +4,21 @@ Feature: Products
     When I create an invalid product
     Then I see the "New Product" page
     And I see a "Title can't be blank" message
+
+    #  Scenario:
+    #    Given I am signed in
+    #    And a product exists
+    #    And I have the product in my basket
+    #    And I am deleting the product
+    #    When I delete the product
+    #    Then I see the "Delete Product" page
+    #    And I see a "Line Items present" error
+
+  Scenario:
+    Given I am signed in
+    And a product exists
+    And I am deleting the product
+    And someone else deletes the product
+    When I delete the product
+    Then I see the "Products" page
+    And I see a "We couldn't find that product" alert

--- a/features/step_definitions/baskets_steps.rb
+++ b/features/step_definitions/baskets_steps.rb
@@ -1,0 +1,35 @@
+### GIVEN
+
+Given(/^I am on the "Shop" page$/) do
+  shop_page = ShopPage.new
+  shop_page.visit_page
+end
+
+Given(/^I don't have a basket$/) do
+  expect(Basket.all).to have(0).baskets
+end
+
+### WHEN
+
+When(/^I add the product to my basket$/) do
+  product = Product.last
+  shop_page = ShopPage.new
+  shop_page.add_to_basket(product)
+end
+
+When(/^I empty my basket$/) do
+  basket_page = BasketPage.new
+  basket_page.empty
+end
+
+When(/^I view the basket$/) do
+  basket_page = BasketPage.new
+  basket_page.visit_page
+end
+
+### THEN ###
+
+Then(/^I see the product in my basket twice$/) do
+  basket_page = BasketPage.new
+  expect(basket_page).to have_product_twice
+end

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -1,0 +1,50 @@
+### GIVEN
+
+Given(/^I have an empty basket$/) do
+  # noop
+end
+
+Given(/^I have checked out my basket$/) do
+  basket_page = BasketPage.new
+  basket_page.checkout
+end
+
+Given(/^I have the product in my basket$/) do
+  product = Product.last
+  shop_page = ShopPage.new
+  shop_page.visit_page
+  shop_page.add_to_basket(product)
+end
+
+### WHEN
+
+When(/^I checkout my basket$/) do
+  basket_page = BasketPage.new
+  basket_page.checkout
+end
+
+When(/^I create the order$/) do
+  new_order_page = NewOrderPage.new
+  new_order_page.create(
+    name: 'Alphonso Quigley',
+    address: '1 Test Street, Testerton TE5 7TE',
+    email: 'alphonso.quigley@example.com'
+  )
+end
+
+When(/^I create the order incorrectly$/) do
+  new_order_page = NewOrderPage.new
+  new_order_page.create
+end
+
+When(/^I visit the "New order" page$/) do
+  new_order_page = NewOrderPage.new
+  new_order_page.visit_page
+end
+
+### THEN ###
+
+Then(/^I see some validation messages$/) do
+  new_order_page = NewOrderPage.new
+  expect(new_order_page).to have_validation_messages
+end

--- a/features/step_definitions/products_steps.rb
+++ b/features/step_definitions/products_steps.rb
@@ -1,3 +1,21 @@
+### GIVEN ###
+
+Given(/^I am deleting the product$/) do
+  product = Product.last
+  delete_product_page = DeleteProductPage.new
+  delete_product_page.visit_page(product)
+end
+
+Given(/^someone else deletes the product$/) do
+  product = Product.last
+
+  VCR.use_cassette('delete product', match_requests_on: [:host]) do
+    product.destroy
+  end
+
+  expect(Product.all).to have(0).products
+end
+
 ### WHEN ###
 
 When(/^I create an invalid product$/) do
@@ -6,4 +24,16 @@ When(/^I create an invalid product$/) do
   visit new_product_path
 
   new_product_page.create
+end
+
+When(/^I delete the product$/) do
+  delete_product_page = DeleteProductPage.new
+  delete_product_page.delete
+end
+
+### THEN ###
+
+Then(/^I see a "Line Items present" error$/) do
+  delete_product_page = DeleteProductPage.new
+  expect(delete_product_page).to have_line_item_error
 end

--- a/features/support/pages/basket_page.rb
+++ b/features/support/pages/basket_page.rb
@@ -1,0 +1,19 @@
+class BasketPage
+  include Capybara::DSL
+
+  def checkout
+    click_button 'Checkout'
+  end
+
+  def empty
+    click_button('Empty basket')
+  end
+
+  def has_product_twice?
+    has_css?('td', text: '2 ×')
+  end
+
+  def visit_page
+    visit "/baskets/foo"
+  end
+end

--- a/features/support/pages/delete_product_page.rb
+++ b/features/support/pages/delete_product_page.rb
@@ -1,0 +1,18 @@
+class DeleteProductPage
+  include Capybara::DSL
+  include RSpec::Matchers
+
+  def delete
+    VCR.use_cassette('delete product', match_requests_on: [:host]) do
+      click_button('Delete Product')
+    end
+  end
+
+  def has_line_item_error?
+    has_css?('.alert-error li', text: 'Line Items present')
+  end
+
+  def visit_page(product)
+    visit("/products/#{product.id}/delete")
+  end
+end

--- a/features/support/pages/new_order_page.rb
+++ b/features/support/pages/new_order_page.rb
@@ -1,0 +1,19 @@
+class NewOrderPage
+  include Capybara::DSL
+  include RSpec::Matchers
+
+  def create(options = {})
+    fill_in('Name', with: options.fetch(:name, ''))
+    fill_in('Address', with: options.fetch(:address, ''))
+    fill_in('Email', with: options.fetch(:email, ''))
+    click_button('Create Order')
+  end
+
+  def has_validation_messages?
+    has_css?('.alert-error')
+  end
+
+  def visit_page
+    visit '/orders/new'
+  end
+end

--- a/features/support/pages/shop_page.rb
+++ b/features/support/pages/shop_page.rb
@@ -1,0 +1,11 @@
+class ShopPage
+  include Capybara::DSL
+
+  def add_to_basket(product)
+    click_button 'Add to Basket'
+  end
+
+  def visit_page
+    visit '/shop'
+  end
+end

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe BasketsController do
+  describe 'GET "show"' do
+    it 'finds the basket' do
+      basket = Basket.new
+      Basket.stub(:find).once.with('1') { basket }
+      get :show, id: '1'
+      expect(assigns(:basket)).to be basket
+    end
+
+    context 'when a basket can\'t be found' do
+      it 'redirects to the shop' do
+        Basket.stub(:find).once.with('1') do
+          raise ActiveRecord::RecordNotFound
+        end
+        get :show, id: '1'
+        expect(response).to redirect_to shop_url
+      end
+
+      it 'alerts the user' do
+        Basket.stub(:find).once.with('1') do
+          raise ActiveRecord::RecordNotFound
+        end
+        get :show, id: '1'
+        expect(flash[:alert]).to eql I18n.t('baskets.show.alert')
+      end
+    end
+  end
+
+  describe 'DELETE "destroy"' do
+    it 'redirects to the shop' do
+      basket = double(:basket)
+      Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+      Basket.stub(:create).once.with(no_args) { basket }
+      basket.stub(:id).once.with(no_args) { 1 }
+      basket.stub(:destroy).once.with(no_args)
+      delete :destroy, id: '1'
+      expect(response).to redirect_to shop_url
+    end
+  end
+end

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe LineItemsController do
+  describe 'POST "create"' do
+    it 'gets the current basket' do
+      basket = Basket.new
+      product = Product.new
+      session[:basket_id] = 2
+      Basket.stub(:find).once.with(2) { basket }
+      Product.stub(:find).once.with('1') { product }
+      post :create, product_id: '1'
+      expect(assigns(:basket)).to be basket
+    end
+
+    it 'saves the line item' do
+      basket = Basket.new
+      line_item = LineItem.new
+      product = Product.new
+      session[:basket_id] = 2
+      basket.stub(:add_product).once.with(1) { line_item }
+      product.stub(:id).once.with(no_args) { 1 }
+      Basket.stub(:find).once.with(2) { basket }
+      Product.stub(:find).once.with('1') { product }
+      line_item.should_receive(:save).once.with(no_args)
+      post :create, product_id: '1'
+    end
+
+    it 'redirects to the basket' do
+      basket = Basket.new
+      product = Product.new
+      session[:basket_id] = 2
+      Basket.stub(:find).once.with(2) { basket }
+      Product.stub(:find).once.with('1') { product }
+      post :create, product_id: '1'
+      expect(response).to redirect_to basket
+    end
+
+    context 'when there is no current basket' do
+      it 'creates a new basket' do
+        basket = Basket.new
+        product = Product.new
+        basket.stub(:id).once.with(no_args) { 2 }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+        Product.stub(:find).once.with('1') { product }
+        post :create, product_id: '1'
+        expect(assigns(:basket)).to be basket
+      end
+
+      it 'saves the line item to the new basket' do
+        basket = Basket.new
+        line_item = LineItem.new
+        product = Product.new
+        basket.stub(:add_product).once.with(1) { line_item }
+        basket.stub(:id).once.with(no_args) { 2 }
+        product.stub(:id).once.with(no_args) { 1 }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+        Product.stub(:find).once.with('1') { product }
+        line_item.should_receive(:save).once.with(no_args)
+        post :create, product_id: '1'
+      end
+
+      it 'redirects to the new basket' do
+        basket = Basket.new
+        product = Product.new
+        basket.stub(:id).once.with(no_args) { 2 }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+        Product.stub(:find).once.with('1') { product }
+        post :create, product_id: '1'
+        expect(response).to redirect_to basket
+      end
+    end
+  end
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe OrdersController do
+  describe 'GET "new"' do
+    it 'creates a new order' do
+      basket = double
+      order = double
+      session[:basket_id] = 1
+      basket.stub(:line_items).once.with(no_args) { [double] }
+      Basket.stub(:find).once.with(1) { basket }
+      Order.stub(:new).once.with(no_args) { order }
+
+      get :new
+
+      expect(assigns(:order)).to be order
+    end
+
+    context 'when there\'s no current basket' do
+      it 'redirects to the shop' do
+        basket = double
+        basket.stub(:id).once.with(no_args) { 1 }
+        basket.stub(:line_items).once.with(no_args) { [] }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+
+        get :new
+
+        expect(response).to redirect_to shop_url
+      end
+
+      it 'sets a notice' do
+        basket = double
+        basket.stub(:id).once.with(no_args) { 1 }
+        basket.stub(:line_items).once.with(no_args) { [] }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+
+        get :new
+
+        expect(flash[:notice]).to eql I18n.t('orders.new.notice')
+      end
+    end
+
+    context 'when there are no items in the basket' do
+      it 'redirects to the shop' do
+        basket = double
+        session[:basket_id] = 1
+        basket.stub(:line_items).once.with(no_args) { [] }
+        Basket.stub(:find).once.with(1) { basket }
+
+        get :new
+
+        expect(response).to redirect_to shop_url
+      end
+
+      it 'sets a notice' do
+        basket = double
+        session[:basket_id] = 1
+        basket.stub(:line_items).once.with(no_args) { [] }
+        Basket.stub(:find).once.with(1) { basket }
+
+        get :new
+
+        expect(flash[:notice]).to eql I18n.t('orders.new.notice')
+      end
+    end
+  end
+
+  describe 'POST "create"' do
+    it 'redirects to the shop' do
+      basket = double
+      mailer = double
+      order = double
+      basket.stub(:id).once.with(no_args) { 1 }
+      mailer.stub(:deliver).once.with(no_args)
+      order.stub(:add_line_items_from_basket).once.with(basket)
+      order.stub(:save).once.with(no_args) { true }
+      Basket.stub(:create).once.with(no_args) { basket }
+      Basket.stub(:destroy).once.with(1)
+      Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+      Mailer.stub(:order_received).once.with(order) { mailer }
+      Order.stub(:new).once.with({}) { order }
+      post :create, order: {}
+      expect(response).to redirect_to shop_url
+    end
+
+    context 'when the order can\'t be saved' do
+      it 'renders the new order view' do
+        basket = double
+        order = double
+        basket.stub(:id).once.with(no_args) { 1 }
+        order.stub(:add_line_items_from_basket).once.with(basket)
+        order.stub(:save).once.with(no_args) { false }
+        Basket.stub(:create).once.with(no_args) { basket }
+        Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
+        Order.stub(:new).once.with({}) { order }
+        post :create, order: {}
+        expect(response).to render_template :new
+      end
+    end
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -11,11 +11,6 @@ describe PagesController do
       response.should be_success
     end
 
-    it "should have the right title" do
-      get 'home'
-      expect(assigns(:title)).to eql("Home")
-    end
-
     it "gets the next three events" do
       event = double(:event)
       Event.stub(:find).with(:all, limit: 3).and_return([event])

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -24,27 +24,79 @@ describe ProductsController do
   end
 
   describe 'DELETE "destroy"' do
-    let(:id) { 'foo' }
-    let(:params) { {id: id} }
-    let(:product) { double(:product, destroy: nil) }
+    it 'sets the product' do
+      product = double(:product)
+      product.stub(:destroy).with(no_args).once.and_return(true)
+      Product.stub(:find).with('1').once.and_return(product)
 
-    before do
-      Product.stub(:find).with(id) { product }
+      delete :destroy, id: '1'
+
+      expect(assigns(:product)).to be product
     end
 
     it 'destroys the product' do
-      product.should_receive(:destroy)
-      delete :destroy, params
+      product = double(:product)
+      Product.stub(:find).with('1').once.and_return(product)
+
+      product.should_receive(:destroy).with(no_args).once.and_return(true)
+
+      delete :destroy, id: '1'
+    end
+
+    it 'redirects to the products index' do
+      product = double(:product)
+      product.stub(:destroy).with(no_args).once.and_return(true)
+      Product.stub(:find).with('1').once.and_return(product)
+
+      delete :destroy, id: '1'
+
+      expect(response).to redirect_to products_url
     end
 
     it 'sets the notice flash' do
-      delete :destroy, params
-      expect(flash[:notice]).to eql('Product was deleted.')
+      product = double(:product)
+      product.stub(:destroy).with(no_args).once.and_return(true)
+      Product.stub(:find).with('1').once.and_return(product)
+
+      delete :destroy, id: '1'
+
+      expect(flash[:notice]).to eql I18n.t('products.destroy.notice')
     end
 
-    it 'redirects to the index products page' do
-      delete :destroy, params
-      expect(response).to redirect_to(products_url)
+    context 'when the product can\'t be found' do
+      it 'redirects to the products index' do
+        Product.stub(:find).
+          with('1').
+          once.
+          and_raise(ActiveRecord::RecordNotFound)
+
+        delete :destroy, id: '1'
+
+        expect(response).to redirect_to products_url
+      end
+
+      it 'sets the alert flash' do
+        Product.stub(:find).
+          with('1').
+          once.
+          and_raise(ActiveRecord::RecordNotFound)
+
+        delete :destroy, id: '1'
+
+        expect(flash[:alert]).to eql I18n.t('products.destroy.alert')
+      end
+    end
+
+    context 'when the product can\'t be destroyed' do
+      it 'renders the delete view' do
+        product = double(:product)
+        product.stub(:destroy).with(no_args).once.and_return(false)
+        Product.stub(:find).with('1').once.and_return(product)
+
+        delete :destroy, id: '1'
+
+        expect(response).to render_template :delete
+      end
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
     photo_file_name { "photo.jpg" }
     photo_content_type { "image/jpg" }
     photo_file_size { 1024 }
+    price 599
     title 'foo'
   end
 end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Mailer do
+  describe '#order_received' do
+    it 'renders the sender email' do
+      order = double
+      order.stub(:email).once.with(no_args) { 'test@example.com' }
+      order.stub(:name).once.with(no_args) { 'Alphonso' }
+      order.stub(:line_items).once.with(no_args) { [] }
+      mail = Mailer.order_received(order)
+      expect(mail.from).to eql ['noreply@example.com']
+    end
+  end
+end

--- a/spec/models/basket_spec.rb
+++ b/spec/models/basket_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Basket do
+  describe '#add_product' do
+    it 'returns the current item' do
+      basket = Basket.new
+      current_item = double
+      line_items = double
+      basket.stub(:line_items).once.with(no_args) { line_items }
+      current_item.stub(:quantity).once.with(no_args) { 1 }
+      current_item.stub(:quantity=).once.with(2)
+      line_items.stub(:find_by_product_id).with(3) { current_item }
+      product = basket.add_product(3)
+      expect(product).to be current_item
+    end
+  end
+
+  describe '#total_price' do
+    it 'returns the sum of the line items\' prices' do
+      basket = Basket.new
+      item_1 = double
+      item_2 = double
+      item_1.stub(:total_price).once.with(no_args) { 300 }
+      item_2.stub(:total_price).once.with(no_args) { 600 }
+      basket.stub(:line_items).once.with(no_args) { [item_1, item_2] }
+      expect(basket.total_price).to eql 900
+    end
+  end
+end

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe LineItem do
+  describe '#total_price' do
+    it 'returns the product price multiplied by its quantity' do
+      line_item = LineItem.new
+      product = double
+      line_item.stub(:product).once.with(no_args) { product }
+      line_item.stub(:quantity).once.with(no_args) { 4 }
+      product.stub(:price).once.with(no_args) { 300 }
+      expect(line_item.total_price).to eql 1200
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Order do
+  describe '#add_line_items_from_basket' do
+    it 'adds the basket\'s items to line items' do
+      item = LineItem.new
+      basket = double(:basket)
+      basket.stub(:line_items).once.with(no_args) { [item] }
+      item.stub(:basket_id=).once.with(nil)
+
+      order = Order.new
+      order.add_line_items_from_basket(basket)
+
+      expect(order.line_items).to eql [item]
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,10 +1,17 @@
 require 'spec_helper'
 
 describe Product do
-  it { should allow_mass_assignment_of(:description) }
-  it { should allow_mass_assignment_of(:photo) }
-  it { should allow_mass_assignment_of(:title) }
+  describe '#ensure_not_referenced_by_any_line_item' do
+    it 'returns true' do
+      product = Product.new
+      product.stub(:line_items).once.with(no_args) { [] }
+      expect(product.send(:ensure_not_referenced_by_any_line_item)).to be_true
+    end
 
-  it { should validate_presence_of(:title) }
-  it { should validate_uniqueness_of(:title) }
+    it 'returns false' do
+      product = Product.new
+      product.stub(:line_items).once.with(no_args) { [stub] }
+      expect(product.send(:ensure_not_referenced_by_any_line_item)).to be_false
+    end
+  end
 end


### PR DESCRIPTION
Previously, products could only be shown from the “Shop” page, which wasn’t deemed a good user experience. The product list has been moved to the homepage and pagination has been added to make the experience better for the user.
- Implemented a basket feature, but kept it hidden
- Started improving the styling of the homepage
