### PR TITLE
Fix the height of the product thumbnail headings

### DIFF
--- a/app/assets/stylesheets/product_thumbnails.css.scss
+++ b/app/assets/stylesheets/product_thumbnails.css.scss
@@ -36,6 +36,7 @@
 
   h3 {
     font: 16px/24px "Open Sans", sans-serif;
+    height: 2 * 24px;
     text-align: center;
   }
 


### PR DESCRIPTION
https://trello.com/c/8b9eaSkI

Previously, when the product list contained headings that spanned both one and two lines the layout looking untidy, which was not giving the correct impression to our customers. The height of the headings has been fixed to always be equal to two lines.
