### PR TITLE
Show order

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,6 +25,10 @@ class OrdersController < ApplicationController
     end
   end
 
+  def show
+    @order = Order.find(params[:id])
+  end
+
   private
 
   def order_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,10 @@ module ApplicationHelper
     end
   end
 
+  def humanize_price(price)
+    humanized_money_with_symbol(price, no_cents_if_whole: false)
+  end
+
   def title
     "#{content_for(:title).presence || @title} | Radfords of Somerford"
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,4 +12,8 @@ class Order < ActiveRecord::Base
       line_items << item
     end
   end
+
+  def total_price
+    line_items.inject(Money.new(0)) { |total, item| total + item.total_price }
+  end
 end

--- a/app/views/line_items/_line_item.html.erb
+++ b/app/views/line_items/_line_item.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <td><%= line_item.quantity %> &times;</td>
+
+  <td><%= line_item.product.title %></td>
+
+  <td><%= humanize_price(line_item.total_price) %></td>
+</tr>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:title, t('.title')) %>
+
+<h2><%= t('.title') %></h2>
+
+<div class="span8" style="margin-left: 0;">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th><%= t('.quantity') %></th>
+
+        <th><%= t('.product') %></th>
+
+        <th><%= t('.price') %></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <%= render @order.line_items %>
+
+      <tr>
+        <td colspan="2"><%= t('.total') %>:</td>
+
+        <td><%= humanize_price(@order.total_price) %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="span4">
+  <h3><%= t('.customer_information') %></h3>
+
+  <p><%= mail_to(@order.email) %></p>
+
+  <p><%= @order.name %></p>
+
+  <p><%= simple_format(@order.address) %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,13 @@ en:
     new:
       notice: Your basket is empty.
       title: New order
+    show:
+      customer_information: Customer Information
+      price: Price
+      product: Product
+      quantity: Quantity
+      title: Order
+      total: Total
   pages:
     home:
       title: Home

--- a/features/order.feature
+++ b/features/order.feature
@@ -1,0 +1,8 @@
+Feature: Order
+  Scenario: Order exists
+    Given I am signed in
+    And an order exists
+    When I view the order
+    Then I see the order's name
+    And I see the order's address
+    And I see the order's email

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -1,5 +1,9 @@
 ### GIVEN
 
+Given(/^an order exists$/) do
+  FactoryGirl.create(:order)
+end
+
 Given(/^I have an empty basket$/) do
   # noop
 end
@@ -37,6 +41,12 @@ When(/^I create the order incorrectly$/) do
   new_order_page.create
 end
 
+When(/^I view the order$/) do
+  order = Order.last
+  order_page = OrderPage.new(order)
+  order_page.visit_page
+end
+
 When(/^I visit the "New order" page$/) do
   new_order_page = NewOrderPage.new
   new_order_page.visit_page
@@ -47,4 +57,22 @@ end
 Then(/^I see some validation messages$/) do
   new_order_page = NewOrderPage.new
   expect(new_order_page).to have_validation_messages
+end
+
+Then(/^I see the order's address$/) do
+  order = Order.last
+  order_page = OrderPage.new(order)
+  expect(order_page).to have_address
+end
+
+Then(/^I see the order's email$/) do
+  order = Order.last
+  order_page = OrderPage.new(order)
+  expect(order_page).to have_email
+end
+
+Then(/^I see the order's name$/) do
+  order = Order.last
+  order_page = OrderPage.new(order)
+  expect(order_page).to have_name
 end

--- a/features/support/pages/order_page.rb
+++ b/features/support/pages/order_page.rb
@@ -1,0 +1,27 @@
+class OrderPage
+  include Capybara::DSL
+
+  def initialize(order)
+    @order = order
+  end
+
+  def has_address?
+    page.has_content?(order.address)
+  end
+
+  def has_email?
+    page.has_content?(order.email)
+  end
+
+  def has_name?
+    page.has_content?(order.name)
+  end
+
+  def visit_page
+    visit "/orders/#{order.id}"
+  end
+
+  private
+
+  attr_reader :order
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -108,4 +108,20 @@ describe OrdersController do
       end
     end
   end
+
+  describe 'GET "show"' do
+    let(:order) { double(Order) }
+
+    let(:id) { '1' }
+
+    before do
+      controller.stub(:authenticate)
+      Order.stub(:find).with(id).and_return(order)
+    end
+
+    it 'gets the order specified in the params' do
+      get :show, id: id
+      expect(assigns(:order)).to be(order)
+    end
+  end
 end

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :order do
+    name 'Alphonso Quigley'
+    address "1 Test Street\nTesterton\nTE5 7TE"
+    email 'alphonso.quigley@example.com'
+    pay_type 'Check'
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,6 +27,22 @@ describe ApplicationHelper do
     end
   end
 
+  describe '#humanize_price' do
+    subject { helper.humanize_price(price) }
+
+    let(:formatted_price) { '£10.95' }
+    let(:price) { Money.new(1095) }
+
+    before do
+      helper.stub(:humanized_money_with_symbol).
+        with(price, no_cents_if_whole: false).and_return(formatted_price)
+    end
+
+    it 'returns the formatted price with symbol' do
+      expect(subject).to be(formatted_price)
+    end
+  end
+
   describe "#title" do
     it "returns the content for the title" do
       helper.stub(content_for: "Foo")

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Order do
+  let(:order) { Order.new }
+
   describe '#add_line_items_from_basket' do
     it 'adds the basket\'s items to line items' do
       item = LineItem.new
@@ -12,6 +14,21 @@ describe Order do
       order.add_line_items_from_basket(basket)
 
       expect(order.line_items).to have(1).item
+    end
+  end
+
+  describe '#total_price' do
+    subject { order.total_price }
+
+    let(:item_1) { double(LineItem, total_price: Money.new(395)) }
+    let(:item_2) { double(LineItem, total_price: Money.new(1485)) }
+
+    before do
+      order.stub(line_items: [item_1, item_2])
+    end
+
+    it "returns the sum of each line item's total price" do
+      expect(subject).to eql(Money.new(1880))
     end
   end
 end


### PR DESCRIPTION
Previously, there was no page for an administrator to view the details of an order, which was causing difficulties when an administrator needed to see what a customer had ordered and where the order needed to be shipped to. A page has been added that will display all of the information about a specific order.

https://trello.com/c/ss5habYR

![](http://www.reactiongifs.com/r/prthrdr.gif)
