### PR TITLE
Remove RSpec configuration

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---colour
---format Fuubar


### PR DESCRIPTION
Previously, RSpec was being configured in the application, which was overriding any settings that a developer would have on their machine. Removed the configuration from the repository.

https://trello.com/c/1cAk5aFg

![](http://www.reactiongifs.com/r/dnno.gif)
