### PR TITLE
Remove Fuubar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'factory_girl_rails'
-  gem 'fuubar'
   gem 'launchy'
   gem 'shoulda'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,9 +89,6 @@ GEM
       thor (>= 0.13.6)
     friendly_id (5.0.3)
       activerecord (>= 4.0.0)
-    fuubar (1.3.2)
-      rspec (>= 2.14.0, < 3.1.0)
-      ruby-progressbar (~> 1.3)
     geocoder (1.1.9)
     gherkin (2.12.2)
       multi_json (~> 1.3)
@@ -161,10 +158,6 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     request_store (1.0.5)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
     rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -177,7 +170,6 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    ruby-progressbar (1.4.2)
     safe_yaml (1.0.1)
     sass (3.2.16)
     sass-rails (4.0.2)
@@ -244,7 +236,6 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   friendly_id
-  fuubar
   geocoder
   jquery-rails
   kaminari


### PR DESCRIPTION
Previously, we used to include Fuubar to make our RSpec output prettier, but it has since been removed from the RSpec configuration, which makes the inclusion of the Fuubar gem obsolete. Removed the gem from the Gemfile and updated the bundle.

https://trello.com/c/9ldd9z5R

![](http://www.reactiongifs.com/r/chfo.gif)
