### PR TITLE
Remove gemset

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,0 @@
-radfords


### PR DESCRIPTION
Previously, we used to rely on gemsets within Ruby to separate our gems from our global gems, which is no longer required with the advent of Bundler.  Removed the gemset name from the repo so that one is no longer defined.

https://trello.com/c/GMbK0jne

![](http://www.reactiongifs.com/r/butee.gif)
