### PR TITLE
Show all orders

### DIFF
--- a/app/assets/stylesheets/orders.css.scss
+++ b/app/assets/stylesheets/orders.css.scss
@@ -1,0 +1,14 @@
+.orders {
+  .table {
+    .table {
+      td {
+        border-color: transparent;
+
+        &:first-child {
+          width: 1px;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -29,6 +29,10 @@ class OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
+  def index
+    @orders = Order.all
+  end
+
   private
 
   def order_params

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -1,0 +1,23 @@
+<tr>
+  <td><%= link_to(t('.view'), order, class: %w{ btn btn-small btn-success }) %></td>
+
+  <td>
+    <p><%= order.name %></p>
+
+    <p><%= simple_format(order.address) %></p>
+  </td>
+
+  <td>
+    <table class="table">
+      <tbody>
+        <% order.line_items.each do |line_item| %>
+          <tr>
+            <td><%= line_item.quantity %> &times;</td>
+
+            <td><%= line_item.product.title %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </td>
+</tr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,21 @@
+<%= content_for(:title, t('.title')) %>
+
+<div class="page-header">
+  <h2><%= t('.title') %></h2>
+</div>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th><%= t('.action') %></th>
+
+      <th><%= t('.customer') %></th>
+
+      <th><%= t('.items') %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <%= render @orders %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,9 +14,16 @@ en:
     not_found: "We couldn't find the event you were looking for."
   info_text: 'Heads up'
   orders:
+    index:
+      action: Action
+      customer: Customer
+      items: Items
+      title: Orders
     new:
       notice: Your basket is empty.
       title: New order
+    order:
+      view: View
     show:
       customer_information: Customer Information
       price: Price

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -23,3 +23,9 @@ Feature: Orders
     When I create the order incorrectly
     Then I see the "New order" page
     And I see some validation messages
+
+  Scenario: Order exists
+    Given I am signed in
+    And an order exists
+    When I view the orders
+    Then I see the order

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -47,6 +47,11 @@ When(/^I view the order$/) do
   order_page.visit_page
 end
 
+When(/^I view the orders$/) do
+  orders_page = OrdersPage.new
+  orders_page.visit_page
+end
+
 When(/^I visit the "New order" page$/) do
   new_order_page = NewOrderPage.new
   new_order_page.visit_page
@@ -57,6 +62,11 @@ end
 Then(/^I see some validation messages$/) do
   new_order_page = NewOrderPage.new
   expect(new_order_page).to have_validation_messages
+end
+
+Then(/^I see the order$/) do
+  orders_page = OrdersPage.new
+  expect(orders_page).to have(1).order
 end
 
 Then(/^I see the order's address$/) do

--- a/features/support/pages/orders_page.rb
+++ b/features/support/pages/orders_page.rb
@@ -1,0 +1,11 @@
+class OrdersPage
+  include Capybara::DSL
+
+  def orders
+    page.all('tbody tr')
+  end
+
+  def visit_page
+    visit '/orders'
+  end
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -124,4 +124,18 @@ describe OrdersController do
       expect(assigns(:order)).to be(order)
     end
   end
+
+  describe 'GET "index"' do
+    let(:orders) { [double(Order)] }
+
+    before do
+      controller.stub(:authenticate)
+      Order.stub(all: orders)
+    end
+
+    it 'gets all of the orders' do
+      get :index
+      expect(assigns(:orders)).to be(orders)
+    end
+  end
 end


### PR DESCRIPTION
Previously, there was no way to view all orders at the same time, which was causing an issue when an administrator wanted to easily see what customers had been ordering. A list of orders has been added that links off to each individual order page.

https://trello.com/c/DwAdkFpQ

![](http://www.reactiongifs.com/r/drtg.gif)
