### PR TITLE
Collect customers' credit card details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'paperclip', '~> 3.5.3'
 gem 'pg'
 gem 'rails'
 gem 'recipient_interceptor'
+gem 'stripe'
 gem 'unicorn'
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     request_store (1.0.5)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -197,6 +199,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    stripe (1.9.9)
+      mime-types (~> 1.25)
+      multi_json (>= 1.0.4, < 2)
+      rest-client (~> 1.4)
     thor (0.18.1)
     thread_safe (0.3.1)
       atomic (>= 1.1.7, < 2)
@@ -252,6 +258,7 @@ DEPENDENCIES
   sass-rails
   shoulda
   simplecov
+  stripe
   timecop
   uglifier
   unicorn

--- a/app/assets/javascripts/stripe.js
+++ b/app/assets/javascripts/stripe.js
@@ -1,0 +1,21 @@
+jQuery(function ($) {
+  $('#payment-form').submit(function (e) {
+    var $form = $(this);
+    $form.find('button').prop('disabled', true);
+    Stripe.card.createToken($form, stripeResponseHandler);
+    return false;
+  });
+
+  var stripeResponseHandler = function (status, response) {
+    var $form = $('#payment-form');
+
+    if (response.error) {
+      $form.find('.payment-errors').text(response.error.message);
+      $form.find('button').prop('disabled', false);
+    } else {
+      var token = response.id;
+      $form.append($('<input type="hidden" name="stripe_token" />').val(token));
+      $form.get(0).submit();
+    }
+  };
+});

--- a/app/views/application/_javascript.html.erb
+++ b/app/views/application/_javascript.html.erb
@@ -1,0 +1,15 @@
+<%= javascript_include_tag(
+  'application',
+  'http://maps.googleapis.com/maps/api/js?sensor=false'
+) %>
+
+<%= yield(:javascript) %>
+
+<% if Rails.env.production? %>
+  <script>
+    var _gaq=[['_setAccount','UA-36166511-1'],['_trackPageview']];
+    (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+      g.src='//www.google-analytics.com/ga.js';
+      s.parentNode.insertBefore(g,s)}(document,'script'));
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,18 +26,6 @@
     <%= render 'layouts/footer' %>
   </div>
 
-  <%= javascript_include_tag(
-    'application',
-    'http://maps.googleapis.com/maps/api/js?sensor=false'
-  ) %>
-
-  <% if Rails.env.production? %>
-    <script>
-      var _gaq=[['_setAccount','UA-36166511-1'],['_trackPageview']];
-      (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-        g.src='//www.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g,s)}(document,'script'));
-    </script>
-  <% end %>
+  <%= render 'javascript' %>
 <% end %>
 </html>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_for(@order, html: { class: 'form-horizontal' }) do |f| %>
+<%= form_for(@order, html: { class: 'form-horizontal', id: 'payment-form' }) do |f| %>
+  <span class="payment-errors"></span>
+
   <%= render('shared/error_messages', object: f.object) %>
 
   <div class="control-group">
@@ -38,7 +40,33 @@
     </div>
   </div>
 
+  <div class="control-group">
+    <%= label_tag(nil, t('.card_number'), class: 'control-label') %>
+
+    <div class="controls">
+      <%= text_field_tag(nil, nil, class: 'text-field', data: { stripe: 'number' }, size: 20) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= label_tag(nil, t('.cvc'), class: 'control-label') %>
+
+    <div class="controls">
+      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'cvc' }, size: 4) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= label_tag(nil, t('.expiration'), class: 'control-label') %>
+
+    <div class="controls">
+      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'exp-month' }, size: 2) %>
+      /
+      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'exp-year' }, size: 4) %>
+    </div>
+  </div>
+
   <div class="form-actions">
-    <%= f.submit(nil, 'class' => 'btn btn-primary') %>
+    <%= f.button(nil, 'class' => 'btn btn-primary') %>
   </div>
 <% end %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -7,3 +7,11 @@
     <%= render 'form' %>
   </fieldset>
 </div>
+
+<%= content_for(:javascript) do %>
+  <%= javascript_include_tag('https://js.stripe.com/v2/') %>
+
+  <script type="text/javascript">
+    Stripe.setPublishableKey('<%= Rails.configuration.stripe[:publishable_key] %>');
+  </script>
+<% end %>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,6 @@
+Rails.configuration.stripe = {
+  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
+  secret_key: ENV['STRIPE_SECRET_KEY']
+}
+
+Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,10 @@ en:
     not_found: "We couldn't find the event you were looking for."
   info_text: 'Heads up'
   orders:
+    form:
+      card_number: Card number
+      cvc: CVC
+      expiration: Expiration (MM/YYYY)
     index:
       action: Action
       customer: Customer

--- a/features/support/pages/new_order_page.rb
+++ b/features/support/pages/new_order_page.rb
@@ -6,7 +6,10 @@ class NewOrderPage
     fill_in('Name', with: options.fetch(:name, ''))
     fill_in('Address', with: options.fetch(:address, ''))
     fill_in('Email', with: options.fetch(:email, ''))
-    click_button('Create Order')
+
+    VCR.use_cassette('create stripe charge') do
+      click_button('Create Order')
+    end
   end
 
   def has_validation_messages?

--- a/features/support/vcr/create_stripe_charge.yml
+++ b/features/support/vcr/create_stripe_charge.yml
@@ -1,0 +1,148 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.9.9
+      Authorization:
+      - Bearer sk_test_RRndyeSzHDEZdoNMMgy9VoDL
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - "{\"bindings_version\":\"1.9.9\",\"lang\":\"ruby\",\"lang_version\":\"2.1.0
+        p0 (2013-12-25)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"stripe\",\"uname\":\"Darwin
+        Robs-MacBook-Air.local 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47
+        PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64\"}"
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 01 Apr 2014 09:06:07 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '650'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache, no-store
+      Access-Control-Max-Age:
+      - '300'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "object": "customer",
+          "created": 1396343167,
+          "id": "cus_3lvhMbb8uPrQLU",
+          "livemode": false,
+          "description": null,
+          "email": null,
+          "delinquent": false,
+          "metadata": {},
+          "subscriptions": {
+            "object": "list",
+            "total_count": 0,
+            "has_more": false,
+            "url": "/v1/customers/cus_3lvhMbb8uPrQLU/subscriptions",
+            "data": [],
+            "count": 0
+          },
+          "discount": null,
+          "account_balance": 0,
+          "currency": null,
+          "cards": {
+            "object": "list",
+            "total_count": 0,
+            "has_more": false,
+            "url": "/v1/customers/cus_3lvhMbb8uPrQLU/cards",
+            "data": [],
+            "count": 0
+          },
+          "default_card": null,
+          "subscription": null
+        }
+    http_version: 
+  recorded_at: Wed, 31 Jul 2013 23:00:02 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: US-ASCII
+      string: customer=cus_3lvhMbb8uPrQLU&amount=599&description=Order%20for%20Alphonso%20Quigley&currency=gbp
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.9.9
+      Authorization:
+      - Bearer sk_test_RRndyeSzHDEZdoNMMgy9VoDL
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - "{\"bindings_version\":\"1.9.9\",\"lang\":\"ruby\",\"lang_version\":\"2.1.0
+        p0 (2013-12-25)\",\"platform\":\"x86_64-darwin12.0\",\"publisher\":\"stripe\",\"uname\":\"Darwin
+        Robs-MacBook-Air.local 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47
+        PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64\"}"
+      Content-Length:
+      - '96'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 01 Apr 2014 09:06:09 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Access-Control-Max-Age:
+      - '300'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Cache-Control:
+      - no-cache, no-store
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Cannot charge a customer that has no active card",
+            "type": "card_error",
+            "param": "card",
+            "code": "missing"
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Jul 2013 23:00:03 GMT
+recorded_with: VCR 2.8.0

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -76,10 +76,19 @@ describe OrdersController do
       }
     end
 
+    let(:basket) { double(Basket, total_price: Money.new(100)) }
+    let(:customer) { double(Stripe::Customer, id: nil) }
+    let(:order) { double(Order, name: 'Alphonso Quigley') }
+
+    before do
+      controller.stub(current_basket: basket)
+      session[:basket_id] = 1
+      Stripe::Charge.stub(:create)
+      Stripe::Customer.stub(create: customer)
+    end
+
     it 'redirects to the shop' do
-      basket = double
       mailer = double
-      order = double
       basket.stub(:id).once.with(no_args) { 1 }
       mailer.stub(:deliver).once.with(no_args)
       order.stub(:add_line_items_from_basket).once.with(basket)
@@ -95,8 +104,6 @@ describe OrdersController do
 
     context 'when the order can\'t be saved' do
       it 'renders the new order view' do
-        basket = double
-        order = double
         basket.stub(:id).once.with(no_args) { 1 }
         order.stub(:add_line_items_from_basket).once.with(basket)
         order.stub(:save).once.with(no_args) { false }


### PR DESCRIPTION
Previously, we were only collecting how a customer would like to pay for their order without actually taking any payment details, which meant that we weren't getting paid. Integrated Stripe to collect customers' card details when they create an order.

https://trello.com/c/lhpEeBpQ

![](http://www.reactiongifs.com/r/rhpsf.gif)
