### PR TITLE
Refactor the price formatter

### DIFF
--- a/app/views/baskets/show.html.erb
+++ b/app/views/baskets/show.html.erb
@@ -9,14 +9,14 @@
 
       <td><%= item.product.title %></td>
 
-      <td class="item-price"><%= humanized_money_with_symbol(item.total_price, no_cents_if_whole: false) %></td>
+      <td class="item-price"><%= humanize_price(item.total_price) %></td>
     </tr>
   <% end %>
 
   <tr class="total-line">
     <td colspan="2">Total</td>
 
-    <td class="total-cell"><%= humanized_money_with_symbol(@basket.total_price, no_cents_if_whole: false) %></td>
+    <td class="total-cell"><%= humanize_price(@basket.total_price) %></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Previously, the price formatting when showing the basket was being duplicated across the page, which was not good for maintainability. Replaced the formatting with the already existing price helper.

https://trello.com/c/RX2XJ1JJ

![](http://www.reactiongifs.com/r/rfz0hP0.gif)
