### PR TITLE
Extract Stripe charge out of controller

### DIFF
--- a/app/models/charges_customers.rb
+++ b/app/models/charges_customers.rb
@@ -1,0 +1,36 @@
+class ChargesCustomers
+  def initialize(email, card, amount)
+    @email = email
+    @card = card
+    @amount = amount
+  end
+
+  def charge
+    Stripe::Charge.create(
+      amount: amount,
+      currency: 'gbp',
+      customer: customer_id,
+      description: description
+    )
+  end
+
+  def self.charge(email, card, amount)
+    new(email, card, amount).charge
+  end
+
+  private
+
+  attr_reader :amount, :card, :email
+
+  def customer
+    Stripe::Customer.create(card: card, email: email)
+  end
+
+  def description
+    "Order for #{email}"
+  end
+
+  def customer_id
+    customer.id
+  end
+end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -77,14 +77,12 @@ describe OrdersController do
     end
 
     let(:basket) { double(Basket, total_price: Money.new(100)) }
-    let(:customer) { double(Stripe::Customer, id: nil) }
     let(:order) { double(Order, name: 'Alphonso Quigley') }
 
     before do
       controller.stub(current_basket: basket)
       session[:basket_id] = 1
-      Stripe::Charge.stub(:create)
-      Stripe::Customer.stub(create: customer)
+      ChargesCustomers.stub(:charge)
     end
 
     it 'redirects to the shop' do

--- a/spec/models/charges_customers_spec.rb
+++ b/spec/models/charges_customers_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe ChargesCustomers do
+  let(:charger) { ChargesCustomers.new(email, card, amount) }
+
+  let(:amount) { 50 }
+  let(:card) { 'tok_1041T92eZvKYlo2C223xGDdj' }
+  let(:charge) { double(Stripe::Charge) }
+  let(:email) { 'payinguser@example.com' }
+
+  describe '.charge' do
+    subject { ChargesCustomers.charge(email, card, amount) }
+
+    let(:charger) { double(ChargesCustomers, charge: charge) }
+
+    before do
+      ChargesCustomers.stub(:new).with(email, card, amount).
+        and_return(charger)
+    end
+
+    it 'returns the Stripe charge' do
+      expect(subject).to be(charge)
+    end
+  end
+
+  describe '#charge' do
+    subject { charger.charge }
+
+    let(:customer) { double(Stripe::Customer, id: customer_id) }
+    let(:customer_id) { 'cus_41cbOVn85eL5tY' }
+
+    before do
+      Stripe::Charge.stub(:create).with(
+        customer: customer_id,
+        amount: amount,
+        description: "Order for #{email}",
+        currency: 'gbp'
+      ).and_return(charge)
+      Stripe::Customer.stub(:create).with(email: email, card: card).
+        and_return(customer)
+    end
+
+    it 'returns the Stripe charge' do
+      expect(subject).to be(charge)
+    end
+  end
+end


### PR DESCRIPTION
Previously, the customer was charged inside the orders controller, which was causing the create action to be too complicated. The customer charging implementation has been extracted into its own service class.

https://trello.com/c/rGHtlUDC

![](http://www.reactiongifs.com/r/hhlun.gif)
