### PR TITLE
Add a link back to orders

### DIFF
--- a/app/assets/stylesheets/orders.css.scss
+++ b/app/assets/stylesheets/orders.css.scss
@@ -1,4 +1,9 @@
 .orders {
+  .form-actions {
+    margin-left: 0;
+    width: 910px;
+  }
+
   .table {
     .table {
       td {

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -35,3 +35,7 @@
 
   <p><%= simple_format(@order.address) %></p>
 </div>
+
+<div class="form-actions span12">
+  <%= link_to(t('.back'), orders_path, class: 'btn') %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
     order:
       view: View
     show:
+      back: Back
       customer_information: Customer Information
       price: Price
       product: Product


### PR DESCRIPTION
Previously, there was no UI for an adminstrator to use to get back to the orders list, which was making it difficult for the administrator to navigate the site. A "Back" link has been added to the order page.

https://trello.com/c/4EU9RjQx

![](http://www.reactiongifs.com/r/wrkng.gif)
