### PR TITLE
Vary button state for orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -29,6 +29,7 @@ class OrdersController < ApplicationController
 
   def show
     @order = Order.find(params[:id])
+    @order.update_attribute(:viewed, true)
   end
 
   def index

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,5 @@
+module OrdersHelper
+  def show_order_button(viewed)
+    { true => 'btn-success' }.fetch(viewed, 'btn-warning')
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,7 @@ class Order < ActiveRecord::Base
 
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: PAYMENT_TYPES
+  validates :viewed, inclusion: [false, true]
 
   def add_line_items_from_basket(basket)
     basket.line_items.each do |item|

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -1,5 +1,11 @@
 <tr>
-  <td><%= link_to(t('.view'), order, class: %w{ btn btn-small btn-success }) %></td>
+  <td>
+    <%= link_to(
+      t('.view'),
+      order,
+      class: ['btn', 'btn-small', show_order_button(order.viewed)]
+    ) %>
+  </td>
 
   <td>
     <p><%= order.name %></p>

--- a/db/migrate/20140514150115_add_viewed_to_orders.rb
+++ b/db/migrate/20140514150115_add_viewed_to_orders.rb
@@ -1,0 +1,5 @@
+class AddViewedToOrders < ActiveRecord::Migration
+  def change
+    add_column :orders, :viewed, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,78 +9,82 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140122173612) do
+ActiveRecord::Schema.define(version: 20140514150115) do
 
-  create_table "baskets", :force => true do |t|
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "baskets", force: true do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "events", :force => true do |t|
+  create_table "events", force: true do |t|
     t.string   "name"
     t.date     "takes_place_on"
     t.string   "location"
-    t.datetime "created_at",     :null => false
-    t.datetime "updated_at",     :null => false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
-  create_table "line_items", :force => true do |t|
+  create_table "line_items", force: true do |t|
     t.integer  "product_id"
     t.integer  "basket_id"
-    t.datetime "created_at",                :null => false
-    t.datetime "updated_at",                :null => false
-    t.integer  "quantity",   :default => 1
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "quantity",   default: 1
     t.integer  "order_id"
   end
 
-  add_index "line_items", ["basket_id"], :name => "index_line_items_on_basket_id"
+  add_index "line_items", ["basket_id"], name: "index_line_items_on_basket_id", using: :btree
 
-  create_table "orders", :force => true do |t|
+  create_table "orders", force: true do |t|
     t.string   "name"
     t.text     "address"
     t.string   "email"
     t.string   "pay_type"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "viewed",     default: false, null: false
   end
 
-  create_table "products", :force => true do |t|
+  create_table "products", force: true do |t|
     t.string   "title"
     t.text     "description"
     t.string   "image_url"
-    t.datetime "created_at",                            :null => false
-    t.datetime "updated_at",                            :null => false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "slug"
     t.string   "photo_file_name"
     t.string   "photo_content_type"
     t.integer  "photo_file_size"
     t.datetime "photo_updated_at"
-    t.integer  "price_pennies",      :default => 0,     :null => false
-    t.string   "price_currency",     :default => "GBP", :null => false
+    t.integer  "price_pennies",      default: 0,     null: false
+    t.string   "price_currency",     default: "GBP", null: false
   end
 
-  add_index "products", ["slug"], :name => "index_products_on_slug"
+  add_index "products", ["slug"], name: "index_products_on_slug", using: :btree
 
-  create_table "suppliers", :force => true do |t|
+  create_table "suppliers", force: true do |t|
     t.string   "address"
     t.string   "name"
     t.string   "telephone_number"
     t.string   "website"
-    t.datetime "created_at",                                       :null => false
-    t.datetime "updated_at",                                       :null => false
-    t.decimal  "lat",              :precision => 15, :scale => 10
-    t.decimal  "lng",              :precision => 15, :scale => 10
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
+    t.decimal  "lat",              precision: 15, scale: 10
+    t.decimal  "lng",              precision: 15, scale: 10
     t.float    "latitude"
     t.float    "longitude"
   end
 
-  create_table "users", :force => true do |t|
+  create_table "users", force: true do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at",         :null => false
-    t.datetime "updated_at",         :null => false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.string   "encrypted_password"
     t.string   "salt"
   end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -121,12 +121,18 @@ describe OrdersController do
 
     before do
       controller.stub(:authenticate)
+      order.stub(:update_attribute).with(:viewed, true).and_return(order)
       Order.stub(:find).with(id).and_return(order)
     end
 
     it 'gets the order specified in the params' do
       get :show, id: id
       expect(assigns(:order)).to be(order)
+    end
+
+    it 'marks the order as viewed' do
+      get :show, id: id
+      expect(order).to have_received(:update_attribute).with(:viewed, true)
     end
   end
 

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe OrdersHelper do
+  describe '#show_order_button' do
+    subject { helper.show_order_button(viewed) }
+
+    let(:viewed) { false }
+
+    it 'returns "btn-warning"' do
+      expect(subject).to eql('btn-warning')
+    end
+
+    context 'when the order has been viewed' do
+      let(:viewed) { true }
+
+      it 'returns "btn-success"' do
+        expect(subject).to eql('btn-success')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, the link to individual orders was always the same in the order list, which was proving to be confusing to the administrators. The button has been updated to be different depending upon if it has been viewed or not.

https://trello.com/c/BFG7xajl

![](http://www.reactiongifs.com/r/1m.gif)
