### PR TITLE
Rearrange fields in orders list

### DIFF
--- a/app/assets/stylesheets/orders.css.scss
+++ b/app/assets/stylesheets/orders.css.scss
@@ -4,6 +4,10 @@
     width: 910px;
   }
 
+  .quantity {
+    text-align: right;
+  }
+
   .table {
     .table {
       td {

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -8,22 +8,22 @@
   </td>
 
   <td>
-    <p><%= order.name %></p>
-
-    <p><%= simple_format(order.address) %></p>
-  </td>
-
-  <td>
     <table class="table">
       <tbody>
         <% order.line_items.each do |line_item| %>
           <tr>
-            <td><%= line_item.quantity %> &times;</td>
+            <td class="quantity"><%= line_item.quantity %> &times;</td>
 
             <td><%= line_item.product.title %></td>
           </tr>
         <% end %>
       </tbody>
     </table>
+  </td>
+
+  <td>
+    <p><%= order.name %></p>
+
+    <p><%= simple_format(order.address) %></p>
   </td>
 </tr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,11 +7,11 @@
 <table class="table">
   <thead>
     <tr>
-      <th><%= t('.action') %></th>
+      <th class="span2"><%= t('.view') %></th>
+
+      <th class="span6"><%= t('.items') %></th>
 
       <th><%= t('.customer') %></th>
-
-      <th><%= t('.items') %></th>
     </tr>
   </thead>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,10 +19,10 @@ en:
       cvc: CVC
       expiration: Expiration (MM/YYYY)
     index:
-      action: Action
       customer: Customer
       items: Items
       title: Orders
+      view: View
     new:
       notice: Your basket is empty.
       title: New order


### PR DESCRIPTION
Previously, the order details were arranged in such a way that the administrator was having to go back and forth, which was slowing down order preparation. The fields have been rearranged to provide a better flow.

https://trello.com/c/lOXbQ0VU

![](http://www.reactiongifs.com/r/89e1.gif)
