### PR TITLE
Send fulfilment email

### DIFF
--- a/app/controllers/fulfilments_controller.rb
+++ b/app/controllers/fulfilments_controller.rb
@@ -1,0 +1,16 @@
+class FulfilmentsController < ApplicationController
+  def create
+    Mailer.order_shipped(order).deliver
+    redirect_to(order)
+  end
+
+  private
+
+  def order
+    @order ||= Order.find(order_id)
+  end
+
+  def order_id
+    params[:order_id]
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -4,4 +4,13 @@ class Mailer < ActionMailer::Base
 
     mail(from: 'noreply@example.com', to: order.email, subject: t('.subject'))
   end
+
+  def order_shipped(order)
+    @order = order
+    mail(
+      from: 'denise@radfordsofsomerford.co.uk',
+      subject: t('.subject'),
+      to: @order.email
+    )
+  end
 end

--- a/app/views/mailer/order_shipped.text.erb
+++ b/app/views/mailer/order_shipped.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @order.name %>,
+
+All of the items from your order have now been shipped:
+
+<%= render(@order.line_items) %>
+
+They are being shipped to the following address:
+
+<%= @order.address %>
+
+Thank you for ordering from Radfords of Somerford!

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -38,4 +38,9 @@
 
 <div class="form-actions span12">
   <%= link_to(t('.back'), orders_path, class: 'btn') %>
+  <%= button_to(
+    t('.fulfil'),
+    fulfilments_path(order_id: @order.id, method: :post),
+    class: 'btn'
+  ) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,9 @@ en:
   events:
     not_found: "We couldn't find the event you were looking for."
   info_text: 'Heads up'
+  mailer:
+    order_shipped:
+      subject: Shipping confirmation for your order
   orders:
     form:
       card_number: Card number
@@ -31,6 +34,7 @@ en:
     show:
       back: Back
       customer_information: Customer Information
+      fulfil: Fulfil
       price: Price
       product: Product
       quantity: Quantity

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Radfords::Application.routes.draw do
       delete :delete, action: :destroy
     end
   end
+  resources :fulfilments, only: :create
   resources :line_items
   resources :products do
     member { get :delete }

--- a/features/order.feature
+++ b/features/order.feature
@@ -6,3 +6,11 @@ Feature: Order
     Then I see the order's name
     And I see the order's address
     And I see the order's email
+
+  Scenario: Fulfil order
+    Given I am signed in
+    And an order exists
+    When I fulfil the order
+    Then an email is sent to me
+    And the email is from Denise
+    And the email is a shipping confirmation

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -41,6 +41,13 @@ When(/^I create the order incorrectly$/) do
   new_order_page.create
 end
 
+When(/^I fulfil the order$/) do
+  order = Order.last
+  order_page = OrderPage.new(order)
+  order_page.visit_page
+  order_page.fulfil
+end
+
 When(/^I view the order$/) do
   order = Order.last
   order_page = OrderPage.new(order)
@@ -58,6 +65,12 @@ When(/^I visit the "New order" page$/) do
 end
 
 ### THEN ###
+
+Then(/^an email is sent to me$/) do
+  order = Order.last
+  mail = ActionMailer::Base.deliveries.last
+  expect(mail.to).to eql([order.email])
+end
 
 Then(/^I see some validation messages$/) do
   new_order_page = NewOrderPage.new
@@ -85,4 +98,14 @@ Then(/^I see the order's name$/) do
   order = Order.last
   order_page = OrderPage.new(order)
   expect(order_page).to have_name
+end
+
+Then(/^the email is a shipping confirmation$/) do
+  mail = ActionMailer::Base.deliveries.last
+  expect(mail.subject).to eql('Shipping confirmation for your order')
+end
+
+Then(/^the email is from Denise$/) do
+  mail = ActionMailer::Base.deliveries.last
+  expect(mail.from).to eql(['denise@radfordsofsomerford.co.uk'])
 end

--- a/features/support/pages/order_page.rb
+++ b/features/support/pages/order_page.rb
@@ -5,6 +5,10 @@ class OrderPage
     @order = order
   end
 
+  def fulfil
+    click_button('Fulfil')
+  end
+
   def has_address?
     page.has_content?(order.address)
   end

--- a/spec/controllers/fulfilments_controller_spec.rb
+++ b/spec/controllers/fulfilments_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe FulfilmentsController do
+  describe 'POST "create"' do
+    let(:order) { double(Order) }
+    let(:order_id) { '1' }
+    let(:order_url) { "/orders/#{order_id}" }
+    let(:mailer) { double(Mailer, deliver: nil) }
+
+    before do
+      controller.stub(:authenticate)
+      controller.stub(:url_for).with(order).and_return(order_url)
+      Order.stub(:find).with(order_id).and_return(order)
+      Mailer.stub(:order_shipped).with(order).and_return(mailer)
+    end
+
+    it 'delivers the order fulfilled mail' do
+      post :create, order_id: order_id
+      expect(mailer).to have_received(:deliver)
+    end
+
+    it 'redirects to the order page' do
+      post :create, order_id: order_id
+      expect(response).to redirect_to(order_url)
+    end
+  end
+end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -11,4 +11,27 @@ describe Mailer do
       expect(mail.from).to eql ['noreply@example.com']
     end
   end
+
+  describe '.order_shipped' do
+    subject { Mailer.order_shipped(order) }
+
+    let(:order) do
+      double(Order, address: nil, email: email, line_items: [], name: nil)
+    end
+
+    let(:email) { 'alphonso.quigley@example.com' }
+    let(:title) { 'Shipping confirmation for your order' }
+
+    it 'sends a mail from "noreply@example.com"' do
+      expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])
+    end
+
+    it 'sends a mail to the order email' do
+      expect(subject.to).to eql([email])
+    end
+
+    it 'sends a mail with the correct subject' do
+      expect(subject.subject).to eql(title)
+    end
+  end
 end


### PR DESCRIPTION
Previously, there was no way for the administrator to notify customers when their order has been fulfilled, which was caugin confusion for the customers.  Created a fulfilled email and a UI to send the email.

https://trello.com/c/KXIyDIIp

![](http://www.reactiongifs.com/r/carlin.gif)
