### PR TITLE
Remove footnotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'unicorn'
 
 group :development do
   gem 'foreman'
-  gem 'rails-footnotes'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.1)
       sprockets-rails (~> 2.0)
-    rails-footnotes (4.0.0)
-      rails (>= 3.2)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
@@ -256,7 +254,6 @@ DEPENDENCIES
   paperclip
   pg
   rails (~> 4.1.0)
-  rails-footnotes
   rails_12factor
   recipient_interceptor
   rspec-rails (>= 2.14)


### PR DESCRIPTION
Previously, the footnotes gem was being used to display additional information during development, which was turning out to be annoying more than anything else. Removed the gem from the application.

https://trello.com/c/qLNyMdac

![](http://www.reactiongifs.com/r/IHk0aHX.gif)
