### PR TITLE
Add order link

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,6 +5,12 @@
     <ul class="nav">
       <li><%= link_to("Events", events_path, class: nav_class("events")) %></li>
 
+      <li><%= link_to(
+        t('.orders'),
+        orders_path,
+        class: nav_class('orders')
+      ) %></li>
+
       <li><%= link_to("Products", products_path, class: nav_class("products")) %></li>
     </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,9 @@ en:
       notice: Product was deleted.
   sessions:
     unauthenticated: "You need to sign in or sign up before continuing."
+  shared:
+    navbar:
+      orders: Orders
   success_text: 'Well done'
   suppliers:
     update: "You successfully updated the supplier."


### PR DESCRIPTION
Previously, there was no way for an Administrator to navigate to the orders page via a UI, which was making it difficult to see what customers had ordered. A link has been added to the administrator's navigation menu.

https://trello.com/c/irPfsYNX

![](http://www.reactiongifs.com/r/mcrukm.gif)
