### PR TITLE
Maintain ActiveRecord test schema

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,5 @@ RSpec.configure do |config|
     controller.sign_in(user)
   end
 end
+
+ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
Previously, errors were occasionally being thrown because `db:test:prepare` is no longer defined as part of Rails, which was less than helpful. Added a line to the spec helper that will alleviate this.

https://trello.com/c/Hylz6dbR

![](http://www.reactiongifs.com/r/mny.gif)
