### PR TITLE
Ensure email recipients are set

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,4 +1,3 @@
-Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])
 require Rails.root.join('config/smtp')
 Radfords::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -85,3 +84,7 @@ Radfords::Application.configure do
 
   config.action_mailer.default_url_options = { host: 'staging.radfordsofsomerford.co.uk' }
 end
+
+Mail.register_interceptor RecipientInterceptor.new(
+  ENV.fetch('EMAIL_RECIPIENTS')
+)


### PR DESCRIPTION
Previously, there was no check to make sure that email recipients were set in the staging environment, which was causing errors to be thrown in runtime.  Used a `fetch` to get the email recipients from the environments config.

https://trello.com/c/8atR47Ww

![](http://www.reactiongifs.com/r/kerm.gif)
