### PR TITLE
List orders by creation time

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,7 +33,7 @@ class OrdersController < ApplicationController
   end
 
   def index
-    @orders = Order.all
+    @orders = Order.by_created_at
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,6 +7,8 @@ class Order < ActiveRecord::Base
   validates :pay_type, inclusion: PAYMENT_TYPES
   validates :viewed, inclusion: [false, true]
 
+  scope :by_created_at, -> { order('created_at desc') }
+
   def add_line_items_from_basket(basket)
     basket.line_items.each do |item|
       item.basket_id = nil

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -141,7 +141,7 @@ describe OrdersController do
 
     before do
       controller.stub(:authenticate)
-      Order.stub(all: orders)
+      Order.stub(by_created_at: orders)
     end
 
     it 'gets all of the orders' do


### PR DESCRIPTION
Previously, orders were displayed according to when they were last updated, which was causing confusion when administrators wanted to see the latest orders. The order list has been updated to display orders according to when they were created.

https://trello.com/c/IyrjLFzh

![](http://www.reactiongifs.com/r/kbwink.gif)
