### PR TITLE
Update thank you message

### DIFF
--- a/app/assets/stylesheets/shared/flashes/_thank_you.scss
+++ b/app/assets/stylesheets/shared/flashes/_thank_you.scss
@@ -1,0 +1,55 @@
+#thank-you {
+  background: #f7f7f7;
+  border: 1px solid #ddd;
+  color: #333;
+  margin: 0 0 12px 0;
+  padding: 19.5px;
+
+  em {
+    font-style: normal;
+    font-weight: bold;
+  }
+
+  h2 {
+    border: none;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 36px;
+    line-height: 45px;
+    margin: 0 0 18px 0;
+  }
+
+  li {
+    display: inline-block;
+    font-size: 16px;
+    line-height: 24px;
+    margin-bottom: 12px;
+    margin-left: 1.7968464%;
+    width: 215px;
+
+    &:nth-child(4n+1) {
+      margin-left: 0;
+    }
+  }
+
+  p, ul {
+    font-family: Georgia, serif;
+    font-size: 16px;
+    line-height: 24px;
+    margin: 0 0 12px 0;
+  }
+
+  span {
+    display: block;
+    margin: 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  ul {
+    font-size: 0;
+    list-style-type: none;
+    margin: 0;
+    overflow: hidden;
+  }
+}

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -20,8 +20,9 @@ class OrdersController < ApplicationController
     if @order.save
       Basket.destroy(session[:basket_id])
       session[:basket_id] = nil
+      session[:order_id] = @order.id
       Mailer.order_received(@order).deliver
-      redirect_to shop_url, notice: 'Thank you for your order.'
+      redirect_to root_url, flash: { partial: 'thank_you' }
     else
       render action: "new"
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,12 @@ class PagesController < ApplicationController
 
   def home
     @events = Event.limit(3)
+
+    if session[:order_id]
+      @order = Order.find(session[:order_id])
+      session[:order_id] = nil
+    end
+
     @products = Product.page(params[:page])
   end
 

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,0 +1,11 @@
+<% flash.each do |key, value| %>
+  <% if flash[:partial] %>
+    <%= render(partial: "/shared/flashes/#{flash[:partial]}") %>
+  <% else %>
+    <% alert_type = flash_message_class(key) %>
+
+    <%= content_tag(:div, class: ['alert', "alert-#{alert_type}"]) do %>
+      <strong><%= t("#{alert_type}_text") %>!</strong> <%= value %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,13 +14,8 @@
 
     <%= render 'layouts/header' %>
     <div class="main">
-      <% flash.each do | key, value | %>
-        <% alert_type = flash_message_class(key) %>
+      <%= render 'flashes' %>
 
-        <%= content_tag(:div, class: ['alert', "alert-#{alert_type}"]) do %>
-          <strong><%= t("#{alert_type}_text") %>!</strong> <%= value %>
-        <% end %>
-      <% end %>
       <%= yield %>
     </div>
     <%= render 'layouts/footer' %>

--- a/app/views/shared/flashes/_thank_you.html.erb
+++ b/app/views/shared/flashes/_thank_you.html.erb
@@ -1,0 +1,19 @@
+<div id="thank-you">
+  <h2>Thank you</h2>
+
+  <p>Your order was placed successfully</p>
+
+  <p>You've just purchased this</p>
+
+  <ul>
+    <% @order.line_items.each do |item| %>
+      <li><%= image_tag(item.product.photo.url(:thumbnail)) %><span><%= item.quantity %>&times; <%= item.product.title %></span></li>
+    <% end %>
+  </ul>
+
+  <p>Your Order ID is: <em><%= @order.id %></em></p>
+
+  <p>An email receipt containing information about your order will soon follow. Please keep it for your records.</p>
+
+  <p>Thank you for shopping at <%= link_to('Radfords of Somerford', root_path) %></p>
+</div>

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -12,8 +12,8 @@ Feature: Orders
     And I have the product in my basket
     And I have checked out my basket
     When I create the order
-    Then I see the "Shop" page
-    And I see a "Thank you for your order" notice
+    Then I see the "Home" page
+    And I see a "Thank you" message
 
   Scenario:
     Given I am signed in

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -77,7 +77,7 @@ describe OrdersController do
     end
 
     let(:basket) { double(Basket, total_price: Money.new(100)) }
-    let(:order) { double(Order, name: 'Alphonso Quigley') }
+    let(:order) { double(Order, id: 2, name: 'Alphonso Quigley') }
 
     before do
       controller.stub(current_basket: basket)
@@ -85,7 +85,7 @@ describe OrdersController do
       ChargesCustomers.stub(:charge)
     end
 
-    it 'redirects to the shop' do
+    it 'redirects to the homepage' do
       mailer = double
       basket.stub(:id).once.with(no_args) { 1 }
       mailer.stub(:deliver).once.with(no_args)
@@ -97,7 +97,7 @@ describe OrdersController do
       Mailer.stub(:order_received).once.with(order) { mailer }
       Order.stub(:new).once.with(order_params) { order }
       post :create, order: order_params
-      expect(response).to redirect_to shop_url
+      expect(response).to redirect_to(root_url)
     end
 
     context 'when the order can\'t be saved' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -19,6 +19,26 @@ describe PagesController do
 
       expect(assigns(:events)).to eql [event]
     end
+
+    context 'when there is an order ID in the session' do
+      let(:order) { double(Order) }
+      let(:order_id) { 1 }
+
+      before do
+        Order.stub(:find).with(order_id).and_return(order)
+        session[:order_id] = order_id
+      end
+
+      it 'gets that order' do
+        get :home
+        expect(assigns(:order)).to be(order)
+      end
+
+      it 'removes the order ID from the session' do
+        get :home
+        expect(session[:order_id]).to be_nil
+      end
+    end
   end
 
   describe 'GET "outlets"' do


### PR DESCRIPTION
Previously, customers would just see a simple "thank you" message when there order was created successfully, which was not very detailed and could often be missed. The thank you message has been updated to include details about the order and some helpful copy.

https://trello.com/c/d9an12TT

![](http://www.reactiongifs.com/r/ncmfrtbl.gif)
