### PR TITLE
Add an ActionMailer helper

### DIFF
--- a/spec/support/action_mailer.rb
+++ b/spec/support/action_mailer.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+end


### PR DESCRIPTION
Previously, the ActionMailer deliveries were not being cleared before the specs were being run, which was causing some specs to return false positives.  Added a helper that clears down the ActionMailer deliveries before every test.

https://trello.com/c/w7h2RDAp

![](http://www.reactiongifs.com/r/tupper.gif)
