### PR TITLE
Update copy of order confirmation email

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,8 +1,11 @@
 class Mailer < ActionMailer::Base
   def order_received(order)
     @order = order
-
-    mail(from: 'noreply@example.com', to: order.email, subject: t('.subject'))
+    mail(
+      from: 'Radfords <denise@radfordsofsomerford.co.uk>',
+      subject: t('.subject'),
+      to: @order.email
+    )
   end
 
   def order_shipped(order)

--- a/app/views/mailer/order_received.text.erb
+++ b/app/views/mailer/order_received.text.erb
@@ -1,9 +1,14 @@
 Dear <%= @order.name %>
 
-Thank you for your recent order from The Pragmatic Store.
+This email is to confirm your recent order.
 
-You ordered the following items:
+Date <%= l(@order.created_at) %>
 
-<%= render(@order.line_items) %>
+Shipping address
+<%= @order.address %>
 
-We'll send you a separate email when your order ships.
+<% @order.line_items.each do |item| %>
+<%= "#{item.quantity}x #{item.product.title} for #{humanized_money_with_symbol(item.total_price, no_cents_if_whole: false)}" %>
+<% end %>
+
+Total  : <%= humanized_money_with_symbol(@order.total_price, no_cents_if_whole: false) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
     not_found: "We couldn't find the event you were looking for."
   info_text: 'Heads up'
   mailer:
+    order_received:
+      subject: Order confirmation for your order
     order_shipped:
       subject: Shipping confirmation for your order
   orders:
@@ -58,3 +60,6 @@ en:
   success_text: 'Well done'
   suppliers:
     update: "You successfully updated the supplier."
+  time:
+    formats:
+      default: '%a, %b %-d, %Y at %r'

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,14 +1,34 @@
 require 'spec_helper'
 
 describe Mailer do
-  describe '#order_received' do
-    it 'renders the sender email' do
-      order = double
-      order.stub(:email).once.with(no_args) { 'test@example.com' }
-      order.stub(:name).once.with(no_args) { 'Alphonso' }
-      order.stub(:line_items).once.with(no_args) { [] }
-      mail = Mailer.order_received(order)
-      expect(mail.from).to eql ['noreply@example.com']
+  describe '.order_received' do
+    subject { Mailer.order_received(order) }
+
+    let(:order) do
+      double(
+        Order,
+        address: '',
+        created_at: Time.now,
+        email: email,
+        line_items: [],
+        name: '',
+        total_price: Money.new(0)
+      )
+    end
+
+    let(:email) { 'alphonso.quigley@example.com' }
+    let(:title) { 'Order confirmation for your order' }
+
+    it 'sends a mail from Denise' do
+      expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])
+    end
+
+    it 'sends a mail to the order email' do
+      expect(subject.to).to eql([email])
+    end
+
+    it 'sends a mail with the correct subject' do
+      expect(subject.subject).to eql(title)
     end
   end
 


### PR DESCRIPTION
Previously, the order confirmation email was an absolute shambles and included missing translations and even the wrong application name, which is not very professional. The email has been updated to include the correct translations and more information about the customer's order.

https://trello.com/c/Ipm5MgQ5

![](http://www.reactiongifs.com/r/smrk2.gif)
