### PR TITLE
Add a shipment notification flash

### DIFF
--- a/app/controllers/fulfilments_controller.rb
+++ b/app/controllers/fulfilments_controller.rb
@@ -1,7 +1,7 @@
 class FulfilmentsController < ApplicationController
   def create
     Mailer.order_shipped(order).deliver
-    redirect_to(order)
+    redirect_to(order, notice: t('fulfilments.create.notice'))
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,9 @@ en:
   error_text: 'Oh snap'
   events:
     not_found: "We couldn't find the event you were looking for."
+  fulfilments:
+    create:
+      notice: Shipment notification email sent
   info_text: 'Heads up'
   mailer:
     order_received:

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Features
+  describe 'fulfil order' do
+    let(:email) { user.email }
+    let(:order) { FactoryGirl.create(:order) }
+    let(:order_page) { OrderPage.new(order) }
+    let(:mail) { ActionMailer::Base.deliveries.last }
+    let(:password) { user.password }
+    let(:signin_page) { SigninPage.new(email, password) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    it 'sends an email to the customer' do
+      visit signin_path
+      signin_page.sign_in
+
+      order_page.visit_page
+      order_page.fulfil
+
+      expect(mail.to).to eql([order.email])
+      expect(mail.from).to eql(['denise@radfordsofsomerford.co.uk'])
+      expect(mail.subject).to eql('Shipping confirmation for your order')
+      expect(page).to have_content('email sent')
+    end
+  end
+end

--- a/spec/support/pages/order_page.rb
+++ b/spec/support/pages/order_page.rb
@@ -1,0 +1,31 @@
+class OrderPage
+  include Capybara::DSL
+
+  def initialize(order)
+    @order = order
+  end
+
+  def fulfil
+    click_button('Fulfil')
+  end
+
+  def has_address?
+    page.has_content?(order.address)
+  end
+
+  def has_email?
+    page.has_content?(order.email)
+  end
+
+  def has_name?
+    page.has_content?(order.name)
+  end
+
+  def visit_page
+    visit "/orders/#{order.id}"
+  end
+
+  private
+
+  attr_reader :order
+end

--- a/spec/support/pages/signin_page.rb
+++ b/spec/support/pages/signin_page.rb
@@ -1,0 +1,21 @@
+class SigninPage
+  include Capybara::DSL
+  include Capybara::Node::Matchers
+  include RSpec::Matchers
+
+  def initialize(email = nil, password = nil)
+    @email = email
+    @password = password
+  end
+
+  def sign_in
+    fill_in 'Email', with: email
+    fill_in 'Password', with: password
+
+    click_button 'Sign in'
+  end
+
+  private
+
+  attr_reader :email, :password
+end


### PR DESCRIPTION
Previously, there was no way for an administrator to know that the shipment notification email had been sent successfully, which was causing the email to be sent out multiple times unneccessarily. A flash has been added to be shown when the administrator successfully sends the shipment notification email.

https://trello.com/c/ex8LQ8dA

![](http://www.reactiongifs.com/r/tys.gif)
