### PR TITLE
Remove “Pay type” field

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,10 +1,7 @@
 class Order < ActiveRecord::Base
   has_many :line_items, dependent: :destroy
 
-  PAYMENT_TYPES = ['Check', 'Credit card', 'Purchase order']
-
   validates :name, :address, :email, presence: true
-  validates :pay_type, inclusion: PAYMENT_TYPES
   validates :viewed, inclusion: [false, true]
 
   scope :by_created_at, -> { order('created_at desc') }

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -28,19 +28,6 @@
   </div>
 
   <div class="control-group">
-    <%= f.label(:pay_type, class: 'control-label') %>
-
-    <div class="controls">
-      <%= f.select(
-        :pay_type,
-        Order::PAYMENT_TYPES,
-        'class' => 'select',
-        'prompt' => 'Select a payment method'
-      ) %>
-    </div>
-  </div>
-
-  <div class="control-group">
     <%= label_tag(nil, t('.card_number'), class: 'control-label') %>
 
     <div class="controls">

--- a/db/migrate/20140529153727_remove_pay_type_from_orders.rb
+++ b/db/migrate/20140529153727_remove_pay_type_from_orders.rb
@@ -1,0 +1,9 @@
+class RemovePayTypeFromOrders < ActiveRecord::Migration
+  def up
+    remove_column :orders, :pay_type
+  end
+
+  def down
+    add_column :orders, :pay_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140514150115) do
+ActiveRecord::Schema.define(version: 20140529153727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,15 +38,12 @@ ActiveRecord::Schema.define(version: 20140514150115) do
     t.integer  "order_id"
   end
 
-  add_index "line_items", ["basket_id"], name: "index_line_items_on_basket_id", using: :btree
-
   create_table "orders", force: true do |t|
     t.string   "name"
     t.text     "address"
     t.string   "email"
-    t.string   "pay_type"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "viewed",     default: false, null: false
   end
 

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -3,6 +3,5 @@ FactoryGirl.define do
     name 'Alphonso Quigley'
     address "1 Test Street\nTesterton\nTE5 7TE"
     email 'alphonso.quigley@example.com'
-    pay_type 'Check'
   end
 end


### PR DESCRIPTION
Previously, there was a “Pay type” field on the new order page, which is no longer required because all payments are made using a credit or debit card.  The field has been removed from the new order form.

https://trello.com/c/dinpdxpz

![](http://www.reactiongifs.com/r/wds.gif)
