### PR TITLE
Update payment description

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -12,12 +12,15 @@ class OrdersController < ApplicationController
 
   def create
     @order = Order.new(order_params)
-
-    ChargesCustomers.charge(email, stripe_token, amount)
-
     @order.add_line_items_from_basket(current_basket)
 
     if @order.save
+      ChargesCustomers.charge(
+        email,
+        stripe_token,
+        @order.total_price.cents,
+        @order.id
+      )
       Basket.destroy(session[:basket_id])
       session[:basket_id] = nil
       session[:order_id] = @order.id
@@ -39,10 +42,6 @@ class OrdersController < ApplicationController
 
   private
 
-  def amount
-    total_price.cents
-  end
-
   def email
     params[:email]
   end
@@ -53,9 +52,5 @@ class OrdersController < ApplicationController
 
   def stripe_token
     params[:stripe_token]
-  end
-
-  def total_price
-    current_basket.total_price
   end
 end

--- a/app/models/charges_customers.rb
+++ b/app/models/charges_customers.rb
@@ -1,8 +1,9 @@
 class ChargesCustomers
-  def initialize(email, card, amount)
+  def initialize(email, card, amount, order_id)
     @email = email
     @card = card
     @amount = amount
+    @order_id = order_id
   end
 
   def charge
@@ -14,20 +15,20 @@ class ChargesCustomers
     )
   end
 
-  def self.charge(email, card, amount)
-    new(email, card, amount).charge
+  def self.charge(email, card, amount, order_id)
+    new(email, card, amount, order_id).charge
   end
 
   private
 
-  attr_reader :amount, :card, :email
+  attr_reader :amount, :card, :email, :order_id
 
   def customer
     Stripe::Customer.create(card: card, email: email)
   end
 
   def description
-    "Order for #{email}"
+    "Payment for ##{order_id}"
   end
 
   def customer_id

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -67,6 +67,15 @@ describe OrdersController do
   end
 
   describe 'POST "create"' do
+    let(:order) do
+      double(
+        Order,
+        id: 2,
+        name: 'Alphonso Quigley',
+        total_price: Money.new(100)
+      )
+    end
+
     let(:order_params) do
       {
         'address' => '1 Test Street',
@@ -76,8 +85,7 @@ describe OrdersController do
       }
     end
 
-    let(:basket) { double(Basket, total_price: Money.new(100)) }
-    let(:order) { double(Order, id: 2, name: 'Alphonso Quigley') }
+    let(:basket) { double(Basket) }
 
     before do
       controller.stub(current_basket: basket)

--- a/spec/models/charges_customers_spec.rb
+++ b/spec/models/charges_customers_spec.rb
@@ -1,20 +1,21 @@
 require 'spec_helper'
 
 describe ChargesCustomers do
-  let(:charger) { ChargesCustomers.new(email, card, amount) }
+  let(:charger) { ChargesCustomers.new(email, card, amount, order_id) }
 
   let(:amount) { 50 }
   let(:card) { 'tok_1041T92eZvKYlo2C223xGDdj' }
   let(:charge) { double(Stripe::Charge) }
   let(:email) { 'payinguser@example.com' }
+  let(:order_id) { 1 }
 
   describe '.charge' do
-    subject { ChargesCustomers.charge(email, card, amount) }
+    subject { ChargesCustomers.charge(email, card, amount, order_id) }
 
     let(:charger) { double(ChargesCustomers, charge: charge) }
 
     before do
-      ChargesCustomers.stub(:new).with(email, card, amount).
+      ChargesCustomers.stub(:new).with(email, card, amount, order_id).
         and_return(charger)
     end
 
@@ -33,7 +34,7 @@ describe ChargesCustomers do
       Stripe::Charge.stub(:create).with(
         customer: customer_id,
         amount: amount,
-        description: "Order for #{email}",
+        description: "Payment for ##{order_id}",
         currency: 'gbp'
       ).and_return(charge)
       Stripe::Customer.stub(:create).with(email: email, card: card).


### PR DESCRIPTION
Previously, the description that appeared next to the payment in Stripe did not contain much information, which was making it difficult to link a payment to an order. The order identifier has been added to the payment description to make it easier to link the two elements.

https://trello.com/c/57UoTavI

![](http://www.reactiongifs.com/r/cffe.gif)
