### PR TITLE
Add customer name

### DIFF
--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -7,7 +7,7 @@
     <%= f.label(:name, class: 'control-label') %>
 
     <div class="controls">
-      <%= f.text_field(:name, class: 'text-field') %>
+      <%= f.text_field(:name, class: 'text-field', data: { stripe: 'name' }) %>
     </div>
   </div>
 


### PR DESCRIPTION
Previously, there was no way of identifying the customer within Stripe, which was causing confusion when trying to reconcile orders with payments. The order form has been updated to pass the customer's name through to Stripe upon submission.

https://trello.com/c/KctmJaNd

![](http://www.reactiongifs.com/r/lk.gif)
