### PR TITLE
Add customer description

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -43,7 +43,7 @@ class OrdersController < ApplicationController
   private
 
   def email
-    params[:email]
+    order_params.fetch(:email)
   end
 
   def order_params

--- a/app/models/charges_customers.rb
+++ b/app/models/charges_customers.rb
@@ -11,7 +11,7 @@ class ChargesCustomers
       amount: amount,
       currency: 'gbp',
       customer: customer_id,
-      description: description
+      description: "Payment for ##{order_id}"
     )
   end
 
@@ -24,11 +24,11 @@ class ChargesCustomers
   attr_reader :amount, :card, :email, :order_id
 
   def customer
-    Stripe::Customer.create(card: card, email: email)
-  end
-
-  def description
-    "Payment for ##{order_id}"
+    Stripe::Customer.create(
+      card: card,
+      description: "Customer for ##{order_id}",
+      email: email
+    )
   end
 
   def customer_id

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -79,18 +79,20 @@ describe OrdersController do
     let(:order_params) do
       {
         'address' => '1 Test Street',
-        'email' => 'alphonso.quigley@example.com',
+        'email' => email,
         'name' => 'Alphonso Quigley',
         'pay_type' => 'Check'
       }
     end
 
     let(:basket) { double(Basket) }
+    let(:email) { 'alphonso.quigley@example.com' }
+    let(:stripe_token) { 'tok_103lhG2vVN1WVbyyA7ZfQcLz' }
 
     before do
       controller.stub(current_basket: basket)
       session[:basket_id] = 1
-      ChargesCustomers.stub(:charge)
+      ChargesCustomers.stub(:charge).with(email, stripe_token, 100, 2)
     end
 
     it 'redirects to the homepage' do
@@ -104,7 +106,7 @@ describe OrdersController do
       Basket.stub(:find).once.with(nil) { raise ActiveRecord::RecordNotFound }
       Mailer.stub(:order_received).once.with(order) { mailer }
       Order.stub(:new).once.with(order_params) { order }
-      post :create, order: order_params
+      post :create, order: order_params, stripe_token: stripe_token
       expect(response).to redirect_to(root_url)
     end
 

--- a/spec/models/charges_customers_spec.rb
+++ b/spec/models/charges_customers_spec.rb
@@ -37,8 +37,11 @@ describe ChargesCustomers do
         description: "Payment for ##{order_id}",
         currency: 'gbp'
       ).and_return(charge)
-      Stripe::Customer.stub(:create).with(email: email, card: card).
-        and_return(customer)
+      Stripe::Customer.stub(:create).with(
+        card: card,
+        description: "Customer for ##{order_id}",
+        email: email
+      ).and_return(customer)
     end
 
     it 'returns the Stripe charge' do


### PR DESCRIPTION
Previously, there were no details shown for the customer in Stripe, which was making it difficult to reconcile customers with their orders. The Stripe customer creation call has been updated to include the order identifier and the orders controller has been fixed to pass the correct email address.

https://trello.com/c/c8gsDel1

![](http://www.reactiongifs.com/r/dcknp.gif)
