### PR TITLE
Separate address into separate fields

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,7 +11,7 @@ class OrdersController < ApplicationController
   end
 
   def create
-    @order = Order.new(order_params)
+    @order = Order.new(address: address, email: email, name: name)
     @order.add_line_items_from_basket(current_basket)
 
     if @order.save
@@ -42,12 +42,54 @@ class OrdersController < ApplicationController
 
   private
 
+  def address
+    [
+      address_line_1,
+      address_line_2,
+      address_city,
+      address_post_code,
+      address_county
+    ].compact.join("\n")
+  end
+
+  def address_line_1
+    order_params.fetch(:address_line_1)
+  end
+
+  def address_line_2
+    order_params.fetch(:address_line_2)
+  end
+
+  def address_city
+    order_params.fetch(:address_city)
+  end
+
+  def address_post_code
+    order_params.fetch(:address_post_code)
+  end
+
+  def address_county
+    order_params.fetch(:address_county)
+  end
+
   def email
     order_params.fetch(:email)
   end
 
   def order_params
-    params.require(:order).permit(:name, :address, :email, :pay_type)
+    params.require(:order).permit(
+      :address_line_1,
+      :address_line_2,
+      :address_city,
+      :address_post_code,
+      :address_county,
+      :email,
+      :name
+    )
+  end
+
+  def name
+    order_params.fetch(:name)
   end
 
   def stripe_token

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,8 +1,16 @@
 class Order < ActiveRecord::Base
   has_many :line_items, dependent: :destroy
 
-  validates :name, :address, :email, presence: true
+  validates :name, :email, presence: true
   validates :viewed, inclusion: [false, true]
+
+  attr_accessor(
+    :address_city,
+    :address_county,
+    :address_line_1,
+    :address_line_2,
+    :address_post_code
+  )
 
   scope :by_created_at, -> { order('created_at desc') }
 

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -12,10 +12,42 @@
   </div>
 
   <div class="control-group">
-    <%= f.label(:address, class: 'control-label') %>
+    <%= f.label(:address_line_1, class: 'control-label') %>
 
     <div class="controls">
-      <%= f.text_area(:address, class: 'text-area') %>
+      <%= f.text_field(:address_line_1, class: 'text-field', data: { stripe: 'address-line1' }) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:address_line_2, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_field(:address_line_2, class: 'text-field', data: { stripe: 'address-line2' }) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:address_city, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_field(:address_city, class: 'text-field', data: { stripe: 'address-city' }) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:address_post_code, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_field(:address_post_code, class: 'text-field', data: { stripe: 'address-zip' }) %>
+    </div>
+  </div>
+
+  <div class="control-group">
+    <%= f.label(:address_county, class: 'control-label') %>
+
+    <div class="controls">
+      <%= f.text_field(:address_county, class: 'text-field', data: { stripe: 'address-state' }) %>
     </div>
   </div>
 

--- a/features/support/pages/new_order_page.rb
+++ b/features/support/pages/new_order_page.rb
@@ -1,11 +1,19 @@
 class NewOrderPage
   include Capybara::DSL
+  include Formulaic::Dsl
   include RSpec::Matchers
 
   def create(options = {})
-    fill_in('Name', with: options.fetch(:name, ''))
-    fill_in('Address', with: options.fetch(:address, ''))
-    fill_in('Email', with: options.fetch(:email, ''))
+    fill_form(
+      :order,
+      address_line_1: '1 Test Street',
+      address_line_2: 'Testerton',
+      address_city: 'Testington',
+      address_post_code: 'TE5 7TE',
+      address_county: 'Testshire',
+      email: options.fetch(:email, ''),
+      name: options.fetch(:name, '')
+    )
 
     VCR.use_cassette('create stripe charge') do
       click_button('Create Order')

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,7 +1,10 @@
 FactoryGirl.define do
   factory :order do
-    name 'Alphonso Quigley'
-    address "1 Test Street\nTesterton\nTE5 7TE"
+    address_line_1 '1 Test Street'
+    address_city 'Testerton'
+    address_county 'Testshire'
+    address_post_code 'TE5 7TE'
     email 'alphonso.quigley@example.com'
+    name 'Alphonso Quigley'
   end
 end


### PR DESCRIPTION
Previously, the customer's address was collected in one field, which was causing the full address to not be captured. The field has been split into separate fields to aid the customer.

https://trello.com/c/3amdwkrE

![](http://www.reactiongifs.com/r/vernon.gif)
