### PR TITLE
Update the order form layout

### DIFF
--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(@order, html: { class: 'form-horizontal', id: 'payment-form' }) do |f| %>
+<%= form_for(@order, html: { id: 'payment-form' }) do |f| %>
   <span class="payment-errors"></span>
 
   <%= render('shared/error_messages', object: f.object) %>


### PR DESCRIPTION
Previously, the order form's labels were next to the form's fields, which was proving difficult for customers to read. The labels have been moved to be above the fields.

https://trello.com/c/ECnmOULI

![](http://www.reactiongifs.com/r/tbss.gif)
