### PR TITLE
Restyle the basket page

### DIFF
--- a/app/assets/stylesheets/baskets.css.scss
+++ b/app/assets/stylesheets/baskets.css.scss
@@ -1,0 +1,7 @@
+.baskets {
+  h2 {
+    border-bottom: none;
+    font: bold 24px/1.5em 'Helvetica Neue', sans-serif;
+    margin-bottom: 0;
+  }
+}

--- a/app/views/baskets/show.html.erb
+++ b/app/views/baskets/show.html.erb
@@ -2,7 +2,7 @@
 
 <h2><%= t('.heading') %></h2>
 
-<table>
+<table class="table table-striped">
   <% @basket.line_items.each do |item| %>
     <tr>
       <td><%= item.quantity %> &times;</td>
@@ -20,11 +20,14 @@
   </tr>
 </table>
 
-<%= button_to(t('.checkout'), new_order_path, method: :get) %>
+<div class="form-actions">
+  <%= button_to(t('.checkout'), new_order_path, class: 'btn', method: :get) %>
 
-<%= button_to(
-  t('.empty_basket'),
-  @basket,
-  method: :delete,
-  data: { confirm: t('.confirm') }
-) %>
+  <%= button_to(
+    t('.empty_basket'),
+    @basket,
+    class: 'btn',
+    method: :delete,
+    data: { confirm: t('.confirm') }
+  ) %>
+</div>


### PR DESCRIPTION
Previously, the basket page was just basic markup, which meant that it looked a mess to the customer. The page has been updated to use Bootstrap classes.

https://trello.com/c/8Yj69Ax8

![](http://www.reactiongifs.com/r/tuimma.gif)
