### PR TITLE
Add basket to the home page

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -4,7 +4,7 @@ class LineItemsController < ApplicationController
   def create
     @basket = current_basket
     @basket.add_product(product.id).save
-    redirect_to @basket
+    redirect_to root_url
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@ class PagesController < ApplicationController
   skip_before_filter :authenticate
 
   def home
+    @basket = current_basket
     @events = Event.limit(3)
 
     if session[:order_id]

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -4,4 +4,10 @@ module PagesHelper
       render(partial: 'product_button', locals: { product: product })
     end
   end
+
+  def render_basket(basket)
+    unless basket.line_items.empty?
+      render(basket)
+    end
+  end
 end

--- a/app/views/baskets/_basket.html.erb
+++ b/app/views/baskets/_basket.html.erb
@@ -1,0 +1,29 @@
+<table class="table table-striped">
+  <% @basket.line_items.each do |item| %>
+    <tr>
+    <td><%= item.quantity %> &times;</td>
+
+    <td><%= item.product.title %></td>
+
+    <td class="item-price"><%= humanize_price(item.total_price) %></td>
+  </tr>
+<% end %>
+
+  <tr class="total-line">
+    <td colspan="2">Total</td>
+
+    <td class="total-cell"><%= humanize_price(@basket.total_price) %></td>
+  </tr>
+</table>
+
+<div class="form-actions">
+  <%= button_to(t('.checkout'), new_order_path, class: 'btn', method: :get) %>
+
+  <%= button_to(
+    t('.empty_basket'),
+    @basket,
+    class: 'btn',
+    method: :delete,
+    data: { confirm: t('.confirm') }
+  ) %>
+</div>

--- a/app/views/baskets/show.html.erb
+++ b/app/views/baskets/show.html.erb
@@ -2,32 +2,4 @@
 
 <h2><%= t('.heading') %></h2>
 
-<table class="table table-striped">
-  <% @basket.line_items.each do |item| %>
-    <tr>
-      <td><%= item.quantity %> &times;</td>
-
-      <td><%= item.product.title %></td>
-
-      <td class="item-price"><%= humanize_price(item.total_price) %></td>
-    </tr>
-  <% end %>
-
-  <tr class="total-line">
-    <td colspan="2">Total</td>
-
-    <td class="total-cell"><%= humanize_price(@basket.total_price) %></td>
-  </tr>
-</table>
-
-<div class="form-actions">
-  <%= button_to(t('.checkout'), new_order_path, class: 'btn', method: :get) %>
-
-  <%= button_to(
-    t('.empty_basket'),
-    @basket,
-    class: 'btn',
-    method: :delete,
-    data: { confirm: t('.confirm') }
-  ) %>
-</div>
+<%= render @basket %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,5 +1,7 @@
 <% content_for(:title, t('.title')) %>
 
+<%= render_basket(@basket) %>
+
 <ul class="product-thumbnails">
   <%= render(
     partial: 'product_thumbnails',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,14 +1,15 @@
 en:
   baskets:
-    destroy:
-      notice: Your basket is currently empty.
-    show:
-      alert: Invalid basket.
+    basket:
       checkout: Checkout
       confirm: Are you sure?
       empty_basket: Empty basket
       heading: Your Basket
       title: Basket
+    destroy:
+      notice: Your basket is currently empty.
+    show:
+      alert: Invalid basket.
   error_text: 'Oh snap'
   events:
     not_found: "We couldn't find the event you were looking for."

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -20,5 +20,5 @@ Feature: Baskets
     And I have the product in my basket
     And I am on the "Shop" page
     When I add the product to my basket
-    Then I see the "Basket" page
+    Then I see the "Home" page
     And I see the product in my basket twice

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -16,7 +16,7 @@ describe LineItemsController do
 
     it 'redirects to the saved basket' do
       post :create, product_id: product_id
-      expect(response).to redirect_to(basket_url)
+      expect(response).to redirect_to(root_url)
     end
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -6,6 +6,12 @@ describe PagesController do
   end
 
   describe "GET 'home'" do
+    let(:basket) { double("Basket") }
+
+    before do
+      controller.stub(current_basket: basket)
+    end
+
     it "should be successful" do
       get 'home'
       response.should be_success
@@ -18,6 +24,11 @@ describe PagesController do
       get :home
 
       expect(assigns(:events)).to eql [event]
+    end
+
+    it "gets the current basket" do
+      get :home
+      expect(assigns :basket).to be(basket)
     end
 
     context 'when there is an order ID in the session' do

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -28,4 +28,29 @@ describe PagesHelper do
       end
     end
   end
+
+  describe "#render_basket" do
+    subject { helper.render_basket(basket) }
+
+    let(:basket) { double("Basket", line_items: line_items) }
+    let(:line_item) { double("LineItem") }
+    let(:line_items) { [line_item] }
+    let(:partial) { double("partial") }
+
+    before do
+      helper.stub(:render).with(basket).and_return(partial)
+    end
+
+    it "renders the basket" do
+      expect(subject).to be(partial)
+    end
+
+    context "when the basket has no line items" do
+      let(:line_items) { [] }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, the basket was being shown on its own page, which was causing the user to be taken out of the booking flow. The line item creation flow has been updated to redirect the user to the home page when successful.

https://trello.com/c/7ZgnqcSg

![](http://www.reactiongifs.com/r/rbp.gif)
