### PR TITLE
Use PostgreSQL 9.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ notifications:
     - false
 rvm:
   - 2.1.2
+addons:
+  postgresql: "9.3"


### PR DESCRIPTION
Previously, the default version of Postgres was being used by Travis, which was occassionally causing debugging issues because it is a different version to the one used by Heroku. The Postgres version used by Travis has been set to match that used by Heroku.

https://trello.com/c/DkL0Fl5m

![](http://www.reactiongifs.com/r/giphy1.gif)
