### PR TITLE
Only create a new basket when needed

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@ class PagesController < ApplicationController
   skip_before_filter :authenticate
 
   def home
-    @basket = current_basket
+    @basket = basket
     @events = Event.limit(3)
 
     if session[:order_id]
@@ -23,4 +23,12 @@ class PagesController < ApplicationController
   end
 
   def contact; end
+
+  private
+
+  def basket
+    Basket.find(session[:basket_id])
+  rescue ActiveRecord::RecordNotFound
+    NullBasket.new
+  end
 end

--- a/app/models/null_basket.rb
+++ b/app/models/null_basket.rb
@@ -1,0 +1,5 @@
+class NullBasket
+  def line_items
+    []
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -7,9 +7,15 @@ describe PagesController do
 
   describe "GET 'home'" do
     let(:basket) { double("Basket") }
+    let(:basket_id) { 2 }
+    let(:null_basket) { double("NullBasket") }
+    let(:session_basket) { basket_id }
 
     before do
-      controller.stub(current_basket: basket)
+      Basket.stub(:find).with(basket_id).and_return(basket)
+      Basket.stub(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
+      NullBasket.stub(new: null_basket)
+      session[:basket_id] = session_basket
     end
 
     it "should be successful" do
@@ -48,6 +54,15 @@ describe PagesController do
       it 'removes the order ID from the session' do
         get :home
         expect(session[:order_id]).to be_nil
+      end
+    end
+
+    context "when there is no basket ID in the session" do
+      let(:session_basket) { nil }
+
+      it "assigns a null basket" do
+        get :home
+        expect(assigns(:basket)).to be(null_basket)
       end
     end
   end

--- a/spec/models/null_basket_spec.rb
+++ b/spec/models/null_basket_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe NullBasket do
+  let(:basket) { NullBasket.new }
+
+  describe "#line_items" do
+    subject { basket.line_items }
+
+    it "returns an empty array" do
+      expect(subject).to eql([])
+    end
+  end
+end


### PR DESCRIPTION
Previously, a new basket was being created whenever a user visited the homepage, which was causing unneccessary data to be added to the database. The Pages controller has been updated to only load existing baskets and return a null basket if no basket exists.

https://trello.com/c/I9gBjsd3

![](http://www.reactiongifs.com/r/uhwht.gif)
