### PR TITLE
Upgrade the airbrake gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     addressable (2.3.6)
-    airbrake (3.1.17)
+    airbrake (4.0.0)
       builder
       multi_json
     arel (5.0.1.20140414130214)


### PR DESCRIPTION
- Remove JS notifier from templates and libraries
- Cleanup references to JS notifier in tests
- Merge pull request #297 from airbrake/remove-js-notifier
- Revert "Merge pull request #297 from airbrake/remove-js-notifier"
- Add deprecation warning when using .
- Remove the Airbrake JS notifier for the major release.

https://trello.com/c/KEflOGgR

![](http://www.reactiongifs.com/r/om.gif)
