### PR TITLE
Upgrade the capybara gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
-    capybara (2.2.1)
+    capybara (2.4.1)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)


### PR DESCRIPTION
- 'asserttext', 'assertnotext', 'asserttitle', 'assertnotitle' methods added
- have_title matcher now supports :wait option
- More descriptive have_text error messages
- New modal API ('acceptalert', 'acceptconfirm', 'dismissconfirm', 'acceptprompt', 'dismiss_prompt')
- Warning when attempting to set contents of a readonly element
- Suport for and/or compounding of Capybara's RSpec matchers for RSpec 3
- :filloptions option for 'fillin' method that propagates to 'set' to allow for driver specific modification of how fields are filled in
- Improved selector/filter description in failure messages
- HaveText error message now shows the text checked all the time
- RackTest driver no longer attempts to follow an anchor tag without an href attribute
- Warnings under RSpec 3
- Handle URI schemes like about: correctly
- RSpecs exposedslglobally option is now followed
- New window management API
- Speed improvement for visible text detection in RackTest. Thanks to Phillipe Creux for instigating this
- RSpec 3 compatability
- 'saveandopen_screenshot' functionality
- Server errors raised on visit and synchronize
- CSSHandlers now derives from BasicObject so globally included functions (concat, etc) shouldn't cause issues
- touched reset after session is reset

https://trello.com/c/tvQnXcMN

![](http://www.reactiongifs.com/r/39e.gif)
