### PR TITLE
Move address parts into the object

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,7 +11,7 @@ class OrdersController < ApplicationController
   end
 
   def create
-    @order = Order.new(address: address, email: email, name: name)
+    @order = Order.new(order_params)
     @order.add_line_items_from_basket(current_basket)
 
     if @order.save
@@ -42,36 +42,6 @@ class OrdersController < ApplicationController
 
   private
 
-  def address
-    [
-      address_line_1,
-      address_line_2,
-      address_city,
-      address_post_code,
-      address_county
-    ].compact.join("\n")
-  end
-
-  def address_line_1
-    order_params.fetch(:address_line_1)
-  end
-
-  def address_line_2
-    order_params.fetch(:address_line_2)
-  end
-
-  def address_city
-    order_params.fetch(:address_city)
-  end
-
-  def address_post_code
-    order_params.fetch(:address_post_code)
-  end
-
-  def address_county
-    order_params.fetch(:address_county)
-  end
-
   def email
     order_params.fetch(:email)
   end
@@ -86,10 +56,6 @@ class OrdersController < ApplicationController
       :email,
       :name
     )
-  end
-
-  def name
-    order_params.fetch(:name)
   end
 
   def stripe_token

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -71,17 +71,21 @@ describe OrdersController do
       ].join("\n")
     end
 
+    let(:order_params) do
+      {
+        address_line_1: address_line_1,
+        address_line_2: address_line_2,
+        address_city: address_city,
+        address_post_code: address_post_code,
+        address_county: address_county,
+        email: email,
+        name: name
+      }
+    end
+
     let(:params) do
       {
-        order: {
-          address_line_1: address_line_1,
-          address_line_2: address_line_2,
-          address_city: address_city,
-          address_post_code: address_post_code,
-          address_county: address_county,
-          email: email,
-          name: name
-        },
+        order: order_params,
         stripe_token: stripe_token
       }
     end
@@ -99,7 +103,6 @@ describe OrdersController do
     let(:mailer) { double(Mail::Message, deliver: nil) }
     let(:name) { 'Alphonso Quigley' }
     let(:order) { double(Order, id: id, save: save, total_price: total_price) }
-    let(:order_params) { { address: address, email: email, name: name } }
     let(:save) { true }
     let(:stripe_token) { 'tok_103lhG2vVN1WVbyyA7ZfQcLz' }
     let(:total_price) { Money.new(cents) }

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,7 +1,37 @@
 require 'spec_helper'
 
 describe Order do
-  let(:order) { Order.new }
+  let(:order) do
+    Order.new(
+      address: address,
+      address_line_1: address_line_1,
+      address_line_2: address_line_2,
+      address_city: address_city,
+      address_post_code: address_post_code,
+      address_county: address_county,
+      email: email,
+      name: name
+    )
+  end
+
+  let(:joined_address) do
+    [
+      "G G Batchelor & Son Ltd",
+      "48 Lower Hillmorton Road",
+      "Rugby",
+      "CV21 3TE",
+      "Warwickshire"
+    ].join("\n")
+  end
+
+  let(:address) { nil }
+  let(:address_city) { nil }
+  let(:address_county) { nil }
+  let(:address_line_1) { nil }
+  let(:address_line_2) { nil }
+  let(:address_post_code) { nil }
+  let(:email) { "alphonso.quiqley@example.com" }
+  let(:name) { "Alphonso Quigley" }
 
   describe '#add_line_items_from_basket' do
     let(:basket) { double("Basket", line_items: [item]) }
@@ -14,6 +44,114 @@ describe Order do
     it "clears the item's basket ID" do
       expect(item).to receive(:basket_id=).with(nil)
       order.add_line_items_from_basket(basket)
+    end
+  end
+
+  describe "#address_line_1" do
+    subject { order.address_line_1 }
+
+    let(:address) { joined_address }
+    let(:address_line_1) { "1 Bro Deg" }
+
+    it "returns the first item in the address" do
+      expect(subject).to eql("G G Batchelor & Son Ltd")
+    end
+
+    context "when the address is not set" do
+      let(:address) { nil }
+
+      it "returns address line 1" do
+        expect(subject).to eql address_line_1
+      end
+    end
+  end
+
+  describe "#address_line_2" do
+    subject { order.address_line_2 }
+
+    let(:address) { joined_address }
+    let(:address_line_2) { "Pencoed" }
+
+    it "returns the second item in the address" do
+      expect(subject).to eql("48 Lower Hillmorton Road")
+    end
+
+    context "when the address is not set" do
+      let(:address) { nil }
+
+      it "returns address line 2" do
+        expect(subject).to eql address_line_2
+      end
+    end
+  end
+
+  describe "#address_city" do
+    subject { order.address_city }
+
+    let(:address) { joined_address }
+    let(:address_city) { "Bridgend" }
+
+    it "returns the third item in the address" do
+      expect(subject).to eql "Rugby"
+    end
+
+    context "when the address is not set" do
+      let(:address) { nil }
+
+      it "returns the city" do
+        expect(subject).to eql address_city
+      end
+    end
+  end
+
+  describe "#address_post_code" do
+    subject { order.address_post_code }
+
+    let(:address) { joined_address }
+    let(:address_post_code) { "CF35 6YS" }
+
+    it "returns the fourth item in the address" do
+      expect(subject).to eql "CV21 3TE"
+    end
+
+    context "when the address is not set" do
+      let(:address) { nil }
+
+      it "returns the post code" do
+        expect(subject).to eql address_post_code
+      end
+    end
+  end
+
+  describe "#address_county" do
+    subject { order.address_county }
+
+    let(:address) { joined_address }
+    let(:address_county) { "Glamorgan" }
+
+    it "returns the fifth item in the address" do
+      expect(subject).to eql "Warwickshire"
+    end
+
+    context "when the address is not set" do
+      let(:address) { nil }
+
+      it "returns the county" do
+        expect(subject).to eql address_county
+      end
+    end
+  end
+
+  describe "#make_address" do
+    let(:address_line_1) { "1 Bro Deg" }
+    let(:made_address) { [address_line_1].join("\n") }
+
+    before do
+      order.make_address
+    end
+
+    it "sets the address" do
+      expect(order.address).to eql made_address
     end
   end
 


### PR DESCRIPTION
Previously, the individual address parts of an order where constructed in the
controller, which is not the controller's responsibility. The address items have
been moved into virtual attributes that are constructed in the model.

https://trello.com/c/dWHlndBK

![](http://www.reactiongifs.com/r/vmpt.gif)
