### PR TITLE
Load third-party assets over correct HTTP protocol

### DIFF
--- a/app/views/application/_javascript.html.erb
+++ b/app/views/application/_javascript.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag(
   'application',
-  'http://maps.googleapis.com/maps/api/js?sensor=false'
+  '//maps.googleapis.com/maps/api/js?sensor=false'
 ) %>
 
 <%= yield(:javascript) %>

--- a/app/views/layouts/_stylesheets.html.erb
+++ b/app/views/layouts/_stylesheets.html.erb
@@ -1,4 +1,4 @@
 <%= stylesheet_link_tag(
-  "http://fonts.googleapis.com/css?family=Open+Sans:700",
+  "//fonts.googleapis.com/css?family=Open+Sans:700",
   "application"
 ) %>

--- a/app/views/pages/outlets.html.erb
+++ b/app/views/pages/outlets.html.erb
@@ -70,7 +70,7 @@
         <% end %>
 
         <p>
-          <a href="http://maps.google.com/?q=<%= supplier.latitude %>+<%= supplier.longitude %>"><img src="http://maps.google.com/maps/api/staticmap?size=290x286&amp;maptype=roadmap&amp;sensor=false&amp;center=<%= supplier.latitude %>%2C<%= supplier.longitude %>&amp;zoom=12&amp;style=feature%3Aall%7Celement%3Aall%7Csaturation%3A-100&amp;markers=color%3A0xe87eff%7C<%= supplier.latitude %>%2C<%= supplier.longitude %>" /></a>
+          <a href="http://maps.google.com/?q=<%= supplier.latitude %>+<%= supplier.longitude %>"><img src="//maps.google.com/maps/api/staticmap?size=290x286&amp;maptype=roadmap&amp;sensor=false&amp;center=<%= supplier.latitude %>%2C<%= supplier.longitude %>&amp;zoom=12&amp;style=feature%3Aall%7Celement%3Aall%7Csaturation%3A-100&amp;markers=color%3A0xe87eff%7C<%= supplier.latitude %>%2C<%= supplier.longitude %>" /></a>
         </p>
 
         <p>

--- a/app/views/suppliers/_supplier.html.erb
+++ b/app/views/suppliers/_supplier.html.erb
@@ -21,7 +21,7 @@
         <% end %>
 
         <p>
-          <a href="http://maps.google.com/?q=<%= supplier.lat %>+<%= supplier.lng %>"><img src="http://maps.google.com/maps/api/staticmap?size=290x286&amp;maptype=roadmap&amp;sensor=false&amp;center=<%= supplier.lat %>%2C<%= supplier.lng %>&amp;zoom=12&amp;style=feature%3Aall%7Celement%3Aall%7Csaturation%3A-100&amp;markers=color%3A0xe87eff%7C<%= supplier.lat %>%2C<%= supplier.lng %>" /></a>
+          <a href="http://maps.google.com/?q=<%= supplier.lat %>+<%= supplier.lng %>"><img src="//maps.google.com/maps/api/staticmap?size=290x286&amp;maptype=roadmap&amp;sensor=false&amp;center=<%= supplier.lat %>%2C<%= supplier.lng %>&amp;zoom=12&amp;style=feature%3Aall%7Celement%3Aall%7Csaturation%3A-100&amp;markers=color%3A0xe87eff%7C<%= supplier.lat %>%2C<%= supplier.lng %>" /></a>
         </p>
 
         <p>


### PR DESCRIPTION
Previously, the third-party assets used on the site were only included over unsecured HTTP, which will cause warnings to be raised once all site traffic passes through SSL. The third-party assets have been updated to use the correct protocol depending on the state of the site.

https://trello.com/c/Qnlf8zSN

![](http://www.reactiongifs.com/r/runf.gif)
