### PR TITLE
Update Paperclip to generate scheme-less URLs

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,6 +12,7 @@ class Product < ActiveRecord::Base
       secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
     },
     s3_host_name: ENV['S3_HOST_NAME'],
+    s3_protocol: "",
     styles: {preview: '50x50#', thumbnail: '215x133#'}
 
   validates_attachment_content_type :photo, content_type: /\Aimage/


### PR DESCRIPTION
Previously, all of the URLs generated for any Paperclip uploads were over HTTP, which would cause warnings to be raised when the site is upgraded to SSL. The Paperclip configuration of `Product` has been updated to generate a scheme-less URL.

https://trello.com/c/lldIxMTS

![](http://www.reactiongifs.com/r/ovrjy.gif)
