### PR TITLE
Require the production config in staging

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,3 +1,4 @@
+require_relative "production"
 require Rails.root.join('config/smtp')
 Radfords::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
Previously, the staging environment had its own configuration, which increased the likelihood that there would be unwanted differences between the staging and production environments. The staging configuration has been updated to use the production configuration as a base.

https://trello.com/c/vrT0DXnJ

![](http://www.reactiongifs.com/r/vha.gif)
