### PR TITLE
Force staging and production to use SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,6 +28,8 @@ Radfords::Application.configure do
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files
 
+  config.force_ssl = true
+
   # See everything in the log (default is :info)
   # config.log_level = :debug
 


### PR DESCRIPTION
Previously, all traffic to the staging and production environments was over HTTP, which is not secure when taking payments from customers. The enviroments have been updated to force all content over SSL.

https://trello.com/c/wyQxqHAk

![](http://www.reactiongifs.com/r/wsm.gif)
