### PR TITLE
Refactor the "create" Order action

### DIFF
--- a/app/models/basket.rb
+++ b/app/models/basket.rb
@@ -1,4 +1,5 @@
 class Basket < ActiveRecord::Base
+  belongs_to :order
   has_many :line_items, dependent: :destroy
 
   def add_product(product_id)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,5 @@
 class Order < ActiveRecord::Base
-  has_many :line_items, dependent: :destroy
+  has_one :basket, dependent: :destroy
 
   validates(
     :address_city,
@@ -23,13 +23,6 @@ class Order < ActiveRecord::Base
 
   scope :by_created_at, -> { order('created_at desc') }
 
-  def add_line_items_from_basket(basket)
-    basket.line_items.each do |item|
-      item.basket_id = nil
-      line_items << item
-    end
-  end
-
   def address_line_1
     split_address.fetch(0, @address_line_1)
   end
@@ -48,6 +41,10 @@ class Order < ActiveRecord::Base
 
   def address_county
     split_address.fetch(4, @address_county)
+  end
+
+  def line_items
+    basket.line_items
   end
 
   def make_address

--- a/app/models/order_builder.rb
+++ b/app/models/order_builder.rb
@@ -1,0 +1,39 @@
+class OrderBuilder
+  def initialize(order, stripe_token)
+    @order = order
+    @stripe_token = stripe_token
+  end
+
+  def build
+    ChargesCustomers.charge(email, stripe_token, price, id)
+    mailer.deliver
+  end
+
+  def self.build(order, stripe_token)
+    new(order, stripe_token).build
+  end
+
+  private
+
+  attr_reader :order, :stripe_token
+
+  def email
+    order.email
+  end
+
+  def id
+    order.id
+  end
+
+  def mailer
+    Mailer.order_received(order)
+  end
+
+  def price
+    total_price.cents
+  end
+
+  def total_price
+    order.total_price
+  end
+end

--- a/db/migrate/20140819172705_add_order_id_to_basket.rb
+++ b/db/migrate/20140819172705_add_order_id_to_basket.rb
@@ -1,0 +1,6 @@
+class AddOrderIdToBasket < ActiveRecord::Migration
+  def change
+    add_column :baskets, :order_id, :integer
+    add_index :baskets, :order_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140529153727) do
+ActiveRecord::Schema.define(version: 20140819172705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,10 @@ ActiveRecord::Schema.define(version: 20140529153727) do
   create_table "baskets", force: true do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "order_id"
   end
+
+  add_index "baskets", ["order_id"], name: "index_baskets_on_order_id", using: :btree
 
   create_table "events", force: true do |t|
     t.string   "name"

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,15 +1,17 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe OrdersController do
-  describe 'GET "new"' do
-    let(:basket) { double("Basket", line_items: [double("LineItem")]) }
-    let(:basket_id) { 1 }
+  describe "GET 'new'" do
+    let(:basket) { double("Basket", line_items: items) }
+    let(:items) { [double("LineItem")] }
+    let(:notice) { "Your basket is empty." }
     let(:order) { double "Order" }
 
     before do
-      allow(Basket).to receive(:find).with(basket_id).and_return basket
-      allow(Order).to receive(:new).with({}).and_return order
-      session[:basket_id] = basket_id
+      allow(controller).to receive(:current_basket).and_return basket
+      allow(controller).to receive(:t).with("orders.new.notice").
+        and_return notice
+      allow(Order).to receive(:new).and_return order
     end
 
     it "creates a new order" do
@@ -17,159 +19,121 @@ describe OrdersController do
       expect(assigns :order).to be order
     end
 
-    context 'when there\'s no current basket' do
-      let(:basket_id) { nil }
-
-      it 'redirects to the shop' do
-        basket = double("Basket", id: 1, line_items: [])
-        allow(Basket).to receive(:create) { basket }
-        allow(Basket).to receive(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
-
-        get :new
-
-        expect(response).to redirect_to shop_url
-      end
-
-      it 'sets a notice' do
-        basket = double("Basket", id: 1, line_items: [])
-        allow(Basket).to receive(:create) { basket }
-        allow(Basket).to receive(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
-
-        get :new
-
-        expect(flash[:notice]).to eql I18n.t('orders.new.notice')
-      end
+    it "renders the new page" do
+      get :new
+      expect(response).to render_template :new
     end
 
-    context 'when there are no items in the basket' do
-      it 'redirects to the shop' do
-        basket = double("Basket", line_items: [])
-        session[:basket_id] = 1
-        allow(Basket).to receive(:find).with(1) { basket }
+    context "when the basket is empty" do
+      let(:items) { [] }
 
+      it "sets the flash" do
         get :new
-
-        expect(response).to redirect_to shop_url
+        expect(flash[:notice]).to be notice
       end
 
-      it 'sets a notice' do
-        basket = double("Basket", line_items: [])
-        session[:basket_id] = 1
-        allow(Basket).to receive(:find).with(1) { basket }
-
+      it "redirects to the shop page" do
         get :new
-
-        expect(flash[:notice]).to eql I18n.t('orders.new.notice')
+        expect(response).to redirect_to shop_url
       end
     end
   end
 
-  describe 'POST "create"' do
-    let(:address) do
-      [
-        address_line_1,
-        address_line_2,
-        address_city,
-        address_post_code,
-        address_county
-      ].join("\n")
-    end
-
-    let(:order_params) do
-      {
-        address_line_1: address_line_1,
-        address_line_2: address_line_2,
-        address_city: address_city,
-        address_post_code: address_post_code,
-        address_county: address_county,
-        email: email,
-        name: name
-      }
-    end
-
-    let(:params) do
-      {
-        order: order_params,
-        stripe_token: stripe_token
-      }
-    end
-
-    let(:address_line_1) { '1 Test Road' }
-    let(:address_line_2) { 'Testerton' }
-    let(:address_city) { 'Testington' }
-    let(:address_post_code) { 'TE5 7TE' }
-    let(:address_county) { 'Testshire' }
-    let(:basket_id) { 2 }
-    let(:cents) { 395 }
-    let(:current_basket) { double(Basket) }
-    let(:email) { 'alphonso.quigley@example.com' }
+  describe "POST 'create'" do
+    let(:basket) { double("Basket", line_items: [double("LineItem")]) }
+    let(:exception) { ActiveRecord::RecordInvalid.new(invalid_order) }
     let(:id) { 1 }
-    let(:mailer) { double(Mail::Message, deliver: nil) }
-    let(:name) { 'Alphonso Quigley' }
-    let(:order) { double(Order, id: id, save: save, total_price: total_price) }
-    let(:save) { true }
-    let(:stripe_token) { 'tok_103lhG2vVN1WVbyyA7ZfQcLz' }
-    let(:total_price) { Money.new(cents) }
+    let(:invalid_options) { invalid_params.merge(basket: basket) }
+    let(:invalid_order) { Order.new }
+    let(:invalid_params) { { name: "" } }
+    let(:order) { double("Order", id: id, save!: nil) }
+    let(:order_options) { order_params.merge(basket: basket) }
+    let(:order_params) { { name: "Alphonso Quigley" } }
+    let(:params) { { order: order_params, stripe_token: stripe_token } }
+    let(:stripe_token) { "test_stripe_token" }
 
     before do
-      allow(controller).to receive(:current_basket).and_return(current_basket)
-      allow(order).to receive(:add_line_items_from_basket).with(current_basket)
-      session[:basket_id] = basket_id
-      allow(Basket).to receive(:destroy).with(basket_id)
-      allow(ChargesCustomers).to receive(:charge).
-        with(email, stripe_token, cents, id)
-      allow(Mailer).to receive(:order_received).with(order) { mailer }
-      allow(Order).to receive(:new).with(order_params) { order }
+      allow(controller).to receive(:current_basket).and_return basket
+      allow(invalid_order).to receive(:save!).and_raise exception
+      allow(Order).to receive(:new).with(order_options).and_return order
+      allow(Order).to receive(:new).with(invalid_options).
+        and_return invalid_order
+      allow(OrderBuilder).to receive(:build).with(order, stripe_token)
     end
 
-    it 'redirects to the homepage' do
+    it "creates a new order" do
       post :create, params
-      expect(response).to redirect_to(root_url)
+      expect(assigns :order).to be order
     end
 
-    context 'when the order cannot be saved' do
-      let(:save) { false }
+    it "builds the order" do
+      post :create, params
+      expect(OrderBuilder).to have_received(:build).with(order, stripe_token)
+    end
 
-      it 'renders the new order view' do
+    it "deletes the basket ID from the session" do
+      post :create, params
+      expect(session.fetch :basket_id).to be_nil
+    end
+
+    it "adds the order ID to the session" do
+      post :create, params
+      expect(session.fetch :order_id).to be id
+    end
+
+    it "sets the flash" do
+      post :create, params
+      expect(flash[:partial]).to eql "thank_you"
+    end
+
+    it "redirects the the homepage" do
+      post :create, params
+      expect(response).to redirect_to root_url
+    end
+
+    context "when the order is invalid" do
+      let(:order_params) { invalid_params }
+
+      it "renders the new page" do
         post :create, params
-        expect(response).to render_template(:new)
+        expect(response).to render_template :new
       end
     end
   end
 
-  describe 'GET "show"' do
-    let(:order) { double(Order) }
-
-    let(:id) { '1' }
+  describe "GET 'show'" do
+    let(:id) { "1" }
+    let(:order) { double "Order" }
+    let(:params) { { id: id } }
 
     before do
-      allow(controller).to receive(:authenticate)
-      allow(order).to receive(:update_attribute).with(:viewed, true) { order }
-      allow(Order).to receive(:find).with(id) { order }
+      allow(controller).to receive :authenticate
+      allow(order).to receive(:update_attribute).with(:viewed, true)
+      allow(Order).to receive(:find).with(id).and_return order
     end
 
-    it 'gets the order specified in the params' do
-      get :show, id: id
-      expect(assigns(:order)).to be(order)
+    it "gets the order" do
+      get :show, params
+      expect(assigns :order).to be order
     end
 
-    it 'marks the order as viewed' do
-      get :show, id: id
+    it "marks the order as 'viewed'" do
+      get :show, params
       expect(order).to have_received(:update_attribute).with(:viewed, true)
     end
   end
 
-  describe 'GET "index"' do
-    let(:orders) { [double(Order)] }
+  describe "GET 'index'" do
+    let(:orders) { [] }
 
     before do
-      allow(controller).to receive(:authenticate)
-      allow(Order).to receive(:by_created_at) { orders }
+      allow(controller).to receive :authenticate
+      allow(Order).to receive(:by_created_at).and_return orders
     end
 
-    it 'gets all of the orders' do
+    it "gets the orders" do
       get :index
-      expect(assigns(:orders)).to be(orders)
+      expect(assigns :orders).to be orders
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
+  factory :basket do
+  end
+
   factory :user do
     name 'Robert Whittaker'
     email 'purinkle@example.com'

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     address_city 'Testerton'
     address_county 'Testshire'
     address_post_code 'TE5 7TE'
+    basket
     email 'alphonso.quigley@example.com'
     name 'Alphonso Quigley'
   end

--- a/spec/models/order_builder_spec.rb
+++ b/spec/models/order_builder_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe OrderBuilder do
+  describe ".build" do
+    let(:order) do
+      double("Order", email: email, id: id, total_price: total_price)
+    end
+
+    let(:email) { "alphonso@example.com" }
+    let(:id) { 1 }
+    let(:message) { double("Mail::Message", deliver: nil) }
+    let(:price) { 395_00 }
+    let(:stripe_token) { "test_stripe_token" }
+    let(:total_price) { double("Money", cents: price) }
+
+    before do
+      allow(ChargesCustomers).to receive(:charge).
+        with(email, stripe_token, price, id)
+      allow(Mailer).to receive(:order_received).with(order).and_return message
+
+      OrderBuilder.build(order, stripe_token)
+    end
+
+    it "charges the customer" do
+      expect(ChargesCustomers).to have_received(:charge).
+        with(email, stripe_token, price, id)
+    end
+
+    it "delivers the message" do
+      expect(message).to have_received :deliver
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -33,20 +33,6 @@ describe Order do
   let(:email) { "alphonso.quiqley@example.com" }
   let(:name) { "Alphonso Quigley" }
 
-  describe '#add_line_items_from_basket' do
-    let(:basket) { double("Basket", line_items: [item]) }
-    let(:item) { double("LineItem") }
-
-    before do
-      allow(order).to receive(:line_items).and_return([])
-    end
-
-    it "clears the item's basket ID" do
-      expect(item).to receive(:basket_id=).with(nil)
-      order.add_line_items_from_basket(basket)
-    end
-  end
-
   describe "#address_line_1" do
     subject { order.address_line_1 }
 


### PR DESCRIPTION
Previously, most of the logic that was required to create orders was contained in the orders controller, which was causing the action to become large and unmaintainable. The logic has been extracted from the action into separate classes.

https://trello.com/c/dgrFMz6o

![](http://www.reactiongifs.com/r/conga-line.gif)
