### PR TITLE
Set up staging and production for CDN

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,4 +1,6 @@
 # http://ddollar.github.com/foreman/
+ASSET_HOST=http://assets.example.com
+ASSETS_VERSION=1.0
 AWS_ACCESS_KEY_ID=development_aws_access
 AWS_SECRET_ACCESS_KEY=development_aws_secret
 RACK_ENV=development

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,6 +10,8 @@ Radfords::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  config.static_cache_control = "public, max-age=#{1.year.to_i}"
+
   # Compress JavaScripts and CSS
   config.assets.compress = true
 
@@ -28,6 +30,8 @@ Radfords::Application.configure do
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files
 
+  config.assets.version = ENV.fetch("ASSETS_VERSION")
+
   config.force_ssl = true
 
   # See everything in the log (default is :info)
@@ -41,10 +45,9 @@ Radfords::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  config.serve_static_assets = false
 
   # Enable serving of images, stylesheets, and javascripts from an asset server
-  # config.action_controller.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = ENV.fetch("ASSET_HOST")
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -21,9 +21,6 @@ Radfords::Application.configure do
   # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
-
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
@@ -33,9 +30,6 @@ Radfords::Application.configure do
 
   # Generate digests for assets URLs.
   config.assets.digest = true
-
-  # Version of your assets, change this if you want to expire all your assets.
-  config.assets.version = '1.0'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
@@ -55,9 +49,6 @@ Radfords::Application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
Previously, all of the assets were hosted on a single Heroku instance, which meant that their loading speed would be dependent upon the user’s physical distance from the server. The application has been updated to use a CDN.

https://trello.com/c/Ndwc9o4c

![](http://www.reactiongifs.com/r/huh1.gif)
