### PR TITLE
Add price to button

### DIFF
--- a/app/views/pages/_product_button.html.erb
+++ b/app/views/pages/_product_button.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= button_to(t('.add_to_basket'), line_items_path(product_id: product)) %>
+  <%= button_to("#{humanize_price product.price} - #{t('.add_to_basket')}", line_items_path(product_id: product)) %>
 </div>


### PR DESCRIPTION
Previously, there was no price shown in a product's "Add to Basket" button, which was causing confusion to the customer. The price has been added to the button.

https://trello.com/c/BccxFGpS

![](http://www.reactiongifs.com/r/JWGutV7.gif)
