### PR TITLE
Allow the removal of items from the basket

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -7,7 +7,20 @@ class LineItemsController < ApplicationController
     redirect_to root_url
   end
 
+  def destroy
+    item.destroy
+    redirect_to root_url
+  end
+
   private
+
+  def id
+    params.fetch :id
+  end
+
+  def item
+    LineItem.find id
+  end
 
   def product
     Product.find(product_id)

--- a/app/views/baskets/_basket.html.erb
+++ b/app/views/baskets/_basket.html.erb
@@ -1,12 +1,19 @@
 <table class="table table-striped">
   <% @basket.line_items.each do |item| %>
     <tr>
-    <td><%= item.quantity %> &times;</td>
+      <td><%= item.quantity %> &times;</td>
 
-    <td><%= item.product.title %></td>
+      <td><%= item.product.title %></td>
 
-    <td class="item-price"><%= humanize_price(item.total_price) %></td>
-  </tr>
+      <td class="item-price"><%= humanize_price(item.total_price) %></td>
+
+      <td><%= link_to(
+        t('.destroy'),
+        line_item_path(item),
+        method: :delete,
+        class: 'btn btn-mini btn-danger'
+      ) %></td>
+    </tr>
 <% end %>
 
   <tr class="total-line">

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,9 @@ module Radfords
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.i18n.load_path += Dir[
+      Rails.root.join("config", "locales", "**", "*.{rb,yml}")
+    ]
     config.i18n.enforce_available_locales = true
 
     # JavaScript files you want as :defaults (application.js is always included).

--- a/config/locales/views/baskets/en.yml
+++ b/config/locales/views/baskets/en.yml
@@ -1,0 +1,4 @@
+en:
+  baskets:
+    basket:
+      destroy: Remove

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -19,4 +19,22 @@ describe LineItemsController do
       expect(response).to redirect_to(root_url)
     end
   end
+
+  describe "DELETE 'destroy'" do
+    let(:id) { "1" }
+    let(:item) { double("LineItem", destroy: nil) }
+    let(:params) { { id: id } }
+
+    before { allow(LineItem).to receive(:find).with(id).and_return item }
+
+    it "destroys the line item" do
+      delete :destroy, params
+      expect(item).to have_received :destroy
+    end
+
+    it "redirects to the home page" do
+      delete :destroy, params
+      expect(response).to redirect_to root_url
+    end
+  end
 end

--- a/spec/features/line_items/destroy_spec.rb
+++ b/spec/features/line_items/destroy_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module Features
+  describe "destroy line item" do
+    let(:user) { FactoryGirl.create :user }
+
+    before { FactoryGirl.create :product }
+
+    it "removes the line item from the basket" do
+      visit signin_path
+
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+
+      click_button "Sign in"
+
+      visit root_path
+
+      find("input[type=submit]").click
+
+      click_link "Remove"
+
+      expect(page).to_not have_content("1 ×")
+    end
+  end
+end


### PR DESCRIPTION
Previously, customers were unable to remove individual items from their basket, which meant they would have to empty the entire basket if they wanted to remove an individual item. A "Remove" button has been added to each item in the basket.

https://trello.com/c/j6bYxMO8

![](http://www.reactiongifs.com/r/ws.gif)
