### PR TITLE
Add "increase quantity" button

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -12,6 +12,11 @@ class LineItemsController < ApplicationController
     redirect_to root_url
   end
 
+  def update
+    item.update_attributes item_params
+    redirect_to root_url
+  end
+
   private
 
   def id
@@ -20,6 +25,10 @@ class LineItemsController < ApplicationController
 
   def item
     LineItem.find id
+  end
+
+  def item_params
+    params.require(:line_item).permit :quantity
   end
 
   def product

--- a/app/views/baskets/_basket.html.erb
+++ b/app/views/baskets/_basket.html.erb
@@ -1,6 +1,8 @@
 <table class="table table-striped">
   <% @basket.line_items.each do |item| %>
     <tr>
+      <td><%= button_to("+", line_item_path(item, params: { line_item: { quantity: item.quantity + 1 } }), class: "btn btn-mini", method: :patch) %></td>
+
       <td><%= item.quantity %> &times;</td>
 
       <td><%= item.product.title %></td>
@@ -17,9 +19,13 @@
 <% end %>
 
   <tr class="total-line">
+    <td></td>
+
     <td colspan="2">Total</td>
 
     <td class="total-cell"><%= humanize_price(@basket.total_price) %></td>
+
+    <td></td>
   </tr>
 </table>
 

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -37,4 +37,26 @@ describe LineItemsController do
       expect(response).to redirect_to root_url
     end
   end
+
+  describe "PUT 'update'" do
+    let(:id) { "1" }
+    let(:item) { double "LineItem" }
+    let(:item_params) { { quantity: "2" } }
+    let(:params) { { id: id, line_item: item_params } }
+
+    before do
+      allow(item).to receive(:update_attributes).with item_params
+      allow(LineItem).to receive(:find).with(id).and_return item
+    end
+
+    it "updates the line item" do
+      put :update, params
+      expect(item).to have_received(:update_attributes).with item_params
+    end
+
+    it "redirects to the home page" do
+      put :update, params
+      expect(response).to redirect_to root_url
+    end
+  end
 end

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+module Features
+  describe "destroy line item" do
+    let(:user) { FactoryGirl.create :user }
+
+    before { FactoryGirl.create :product }
+
+    it "removes the line item from the basket" do
+      visit signin_path
+
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+
+      click_button "Sign in"
+
+      visit root_path
+
+      find("input[type=submit]").click
+
+      click_button "+"
+
+      expect(page).to have_content("2 ×")
+    end
+  end
+end


### PR DESCRIPTION
Previously, there was no way for a customer to increase the quantity of items in their basket, which meant they had to explicitly add a product to their basket repeatedly to increase its quantity. Added a new button to the basket that allows the user to increase the quantity of an item in the basket.

https://trello.com/c/dwme2BLI

![](http://www.reactiongifs.com/r/jdhst.gif)
