### PR TITLE
Add "decrease quantity" button

### DIFF
--- a/app/views/baskets/_basket.html.erb
+++ b/app/views/baskets/_basket.html.erb
@@ -1,9 +1,27 @@
 <table class="table table-striped">
   <% @basket.line_items.each do |item| %>
     <tr>
-      <td><%= button_to("+", line_item_path(item, params: { line_item: { quantity: item.quantity + 1 } }), class: "btn btn-mini", method: :patch) %></td>
+      <td><%= button_to(
+        "-",
+        line_item_path(
+          item,
+          params: { line_item: { quantity: item.quantity - 1 } }
+        ),
+        class: "btn btn-mini",
+        method: :patch
+      ) %></td>
 
       <td><%= item.quantity %> &times;</td>
+
+      <td><%= button_to(
+        "+",
+        line_item_path(
+          item,
+          params: { line_item: { quantity: item.quantity + 1 } }
+        ),
+        class: "btn btn-mini",
+        method: :patch
+      ) %></td>
 
       <td><%= item.product.title %></td>
 

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
 module Features
-  describe "destroy line item" do
+  describe "edit line item" do
     let(:user) { FactoryGirl.create :user }
 
     before { FactoryGirl.create :product }
 
-    it "removes the line item from the basket" do
+    it "increases the item's quantity" do
       visit signin_path
 
       fill_in("Email", with: user.email)
@@ -21,6 +21,24 @@ module Features
       click_button "+"
 
       expect(page).to have_content("2 ×")
+    end
+
+    it "decreases the item's quantity" do
+      visit signin_path
+
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+
+      click_button "Sign in"
+
+      visit root_path
+
+      find("input[type=submit]").click
+
+      click_button "+"
+      click_button "-"
+
+      expect(page).to have_content("1 ×")
     end
   end
 end


### PR DESCRIPTION
Previously, there was no way for a customer to decrease the quantity of items in their basket, which meant they had to remove the item completely before adding the correct quantity to the basket. Added a new button to the basket that allows the user to decrease the quantity of an item in the basket.

https://trello.com/c/TVOY3tPB

![](http://www.reactiongifs.com/r/JWGutV7.gif)
