### PR TITLE
Include the order number in customer mails

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -3,7 +3,7 @@ class Mailer < ActionMailer::Base
     @order = order
     mail(
       from: 'Radfords <denise@radfordsofsomerford.co.uk>',
-      subject: t('.subject'),
+      subject: t(".subject", id: @order.id),
       to: @order.email
     )
   end
@@ -12,7 +12,7 @@ class Mailer < ActionMailer::Base
     @order = order
     mail(
       from: 'denise@radfordsofsomerford.co.uk',
-      subject: t('.subject'),
+      subject: t(".subject", id: @order.id),
       to: @order.email
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,9 +19,9 @@ en:
   info_text: 'Heads up'
   mailer:
     order_received:
-      subject: Order confirmation for your order
+      subject: Order confirmation for order %{id}
     order_shipped:
-      subject: Shipping confirmation for your order
+      subject: Shipping confirmation for order %{id}
   orders:
     form:
       card_number: Card number

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -102,7 +102,8 @@ end
 
 Then(/^the email is a shipping confirmation$/) do
   mail = ActionMailer::Base.deliveries.last
-  expect(mail.subject).to eql('Shipping confirmation for your order')
+  order = Order.last
+  expect(mail.subject).to eql("Shipping confirmation for order #{order.id}")
 end
 
 Then(/^the email is from Denise$/) do

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -19,7 +19,7 @@ module Features
 
       expect(mail.to).to eql([order.email])
       expect(mail.from).to eql(['denise@radfordsofsomerford.co.uk'])
-      expect(mail.subject).to eql('Shipping confirmation for your order')
+      expect(mail.subject).to eql("Shipping confirmation for order #{order.id}")
       expect(page).to have_content('email sent')
     end
   end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -10,6 +10,7 @@ describe Mailer do
         address: '',
         created_at: Time.now,
         email: email,
+        id: id,
         line_items: [],
         name: '',
         total_price: Money.new(0)
@@ -17,7 +18,8 @@ describe Mailer do
     end
 
     let(:email) { 'alphonso.quigley@example.com' }
-    let(:title) { 'Order confirmation for your order' }
+    let(:id) { 5 }
+    let(:title) { "Order confirmation for order #{id}" }
 
     it 'sends a mail from Denise' do
       expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])
@@ -36,11 +38,19 @@ describe Mailer do
     subject { Mailer.order_shipped(order) }
 
     let(:order) do
-      double(Order, address: nil, email: email, line_items: [], name: nil)
+      double(
+        Order,
+        address: nil,
+        email: email,
+        id: id,
+        line_items: [],
+        name: nil
+      )
     end
 
     let(:email) { 'alphonso.quigley@example.com' }
-    let(:title) { 'Shipping confirmation for your order' }
+    let(:id) { 5 }
+    let(:title) { "Shipping confirmation for order #{id}" }
 
     it 'sends a mail from "noreply@example.com"' do
       expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])


### PR DESCRIPTION
Previously, the order number was not included in the mails that are sent out to the customer, which was making it difficult for customers to reference their orders. The order number has been added to the subject line of both mails sent from the application.

https://trello.com/c/epeMCNef

![](http://www.reactiongifs.com/r/6j6t9iT.gif)
