### PR TITLE
Tidy up new order validations

### DIFF
--- a/app/assets/javascripts/orders.js
+++ b/app/assets/javascripts/orders.js
@@ -27,7 +27,19 @@ jQuery(function ($) {
         }
       });
 
-      if (response.error) {
+      if (!Stripe.validateCardNumber($(".card-number").val())) {
+        errors.push("This card number looks invalid");
+      }
+
+      if (!Stripe.validateExpiry($(".card-expiry-month").val(), $(".card-expiry-year").val())) {
+        errors.push("Your card's expiration date is invalid");
+      }
+
+      if (!Stripe.validateCVC($(".card-cvc").val())) {
+        errors.push("Your card's security code is invalid");
+      }
+
+      if (errors.length < 1 && response.error) {
         errors.push(response.error.message);
       }
 

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -63,7 +63,13 @@
     <%= label_tag(nil, t('.card_number'), class: 'control-label') %>
 
     <div class="controls">
-      <%= text_field_tag(nil, nil, class: 'text-field', data: { stripe: 'number' }, size: 20) %>
+      <%= text_field_tag(
+        nil,
+        nil,
+        class: 'card-number text-field',
+        data: { stripe: 'number' },
+        size: 20
+      ) %>
     </div>
   </div>
 
@@ -71,7 +77,13 @@
     <%= label_tag(nil, t('.cvc'), class: 'control-label') %>
 
     <div class="controls">
-      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'cvc' }, size: 4) %>
+      <%= text_field_tag(
+        nil,
+        nil,
+        class: 'card-cvc span1 text-field',
+        data: { stripe: 'cvc' },
+        size: 4
+      ) %>
     </div>
   </div>
 
@@ -79,9 +91,21 @@
     <%= label_tag(nil, t('.expiration'), class: 'control-label') %>
 
     <div class="controls">
-      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'exp-month' }, size: 2) %>
+      <%= text_field_tag(
+        nil,
+        nil,
+        class: 'card-expiry-month span1 text-field',
+        data: { stripe: 'exp-month' },
+        size: 2
+      ) %>
       /
-      <%= text_field_tag(nil, nil, class: 'span1 text-field', data: { stripe: 'exp-year' }, size: 4) %>
+      <%= text_field_tag(
+        nil,
+        nil,
+        class: 'card-expiry-year span1 text-field',
+        data: { stripe: 'exp-year' },
+        size: 4
+      ) %>
     </div>
   </div>
 


### PR DESCRIPTION
Previously, the client-side validations on the new order form were too verbose, which was causing confusion for our customers. Updated the validations to read better by using the Stripe library.

https://trello.com/c/TSWVInJ3

![](http://www.reactiongifs.com/r/cmon.gif)
