### PR TITLE
Expose FactoryGirl helper syntax.

### DIFF
--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
Previously, we had to use the full syntax when using FactoryGirl methods, which was becoming cumbersome and making the specs less readable. Added a spec support file that allows us to use the less verbose syntax.

https://trello.com/c/xTBDOPzX

![](http://www.reactiongifs.com/r/kdb.gif)
