### PR TITLE
Set the height of product images

### DIFF
--- a/app/assets/stylesheets/radfords.css.scss
+++ b/app/assets/stylesheets/radfords.css.scss
@@ -575,6 +575,7 @@ img.product-photo {
   -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   float: left;
+  height: 367px;
   margin-left: 0;
   min-height: 1px;
   padding: 15px;


### PR DESCRIPTION
Previously, the height of the images on the "Show Product" page was not set, which meant that the layout of the page changed if the dimensions of the image changed. The stylesheet has been updated to set a fixed height on the product image on the "Show Product" page.

https://trello.com/c/ftX1kpwo

![](http://www.reactiongifs.com/r/suitm.gif)