### PR TITLE
Show new scaled product images

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -5,7 +5,7 @@
     <h1 class="product-title"><%= @product.title %></h1>
   </header>
 
-  <%= image_tag(@product.photo.url, class: 'product-photo') %>
+  <%= image_tag(@product.photo.url(:show), class: 'product-photo') %>
 
   <p class="product-description"><%= @product.description %></p>
 

--- a/features/step_definitions/product_steps.rb
+++ b/features/step_definitions/product_steps.rb
@@ -227,7 +227,8 @@ Then /^I see the product's description$/ do
 end
 
 Then /^I see the product's photo$/ do
-  expect(page).to have_xpath("//img[contains(@src, \"#{@product.photo.url}\")]")
+  product_page = ProductPage.new
+  expect(product_page).to have_image
 end
 
 Then /^I see the product's title$/ do

--- a/features/support/pages/product_page.rb
+++ b/features/support/pages/product_page.rb
@@ -1,0 +1,17 @@
+class ProductPage
+  include Capybara::DSL
+
+  def has_image?
+    has_xpath?("//img[contains(@src, \"#{url}\")]")
+  end
+
+  private
+
+  def product
+    Product.last
+  end
+
+  def url
+    product.photo.url(:show)
+  end
+end


### PR DESCRIPTION
Previously, the images on the "Show Product" page were loaded at full resolution and scaled down, which was affecting the loading times of the page. The "Show Product" view has been updated to load the image at the correct resolution.

https://trello.com/c/gQseuFlZ

![](http://www.reactiongifs.com/r/sitm.gif)