### PR TITLE
Add Rake task to prime development environment

### DIFF
--- a/lib/tasks/development_seeds.rake
+++ b/lib/tasks/development_seeds.rake
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require "factory_girl"
+
+  namespace :dev do
+    desc "Seed data for development environment"
+    task prime: "db:setup" do
+      include FactoryGirl::Syntax::Methods
+
+      # create(:user, email: "user@example.com", password: "password")
+    end
+  end
+end


### PR DESCRIPTION
Previously, there was no automated way to set up the development environment when the repository was first cloned, which meant that developers were working in an inconsistent environment. Added the "dev:prime" Rake task to setup the databases properly.

https://trello.com/c/qeVbXAuQ

![](http://www.reactiongifs.com/r/hyfri.gif)