### PR TITLE
Set the viewport scale

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="initial-scale=1" />
   <title><%= title %></title>
   <%= csrf_meta_tag %>
   <meta name="description" content="Buy homemade jams and preserves online with Radfords of Somerford. Fantastic homemade jams and preserves made with local produce in the heart of Cheshire." />

--- a/public/404.html
+++ b/public/404.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1" />
   <title>The page you were looking for doesn't exist (404)</title>
   <style type="text/css">
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }

--- a/public/422.html
+++ b/public/422.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1" />
   <title>The change you wanted was rejected (422)</title>
   <style type="text/css">
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }

--- a/public/500.html
+++ b/public/500.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="viewport" content="initial-scale=1" />
   <title>We're sorry, but something went wrong (500)</title>
   <style type="text/css">
     body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }


### PR DESCRIPTION
Previously, there was no scale set for the viewport, which meant that mobile devices were loading the page zoomed out to fit the entire content on screen. Set the content's initial scale to 1.

https://trello.com/c/sghuBg6d

![](http://www.reactiongifs.com/r/side-eye.gif)