### PR TITLE
Import all stylesheets

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,3 +11,21 @@
  *= require_self
  *= require_tree .
  */
+
+@import "baskets";
+@import "bootstrap-fileupload.min";
+@import "bootstrap.min";
+@import "datepicker";
+@import "events";
+@import "footer";
+@import "jquery-ui-1.8.16.custom";
+@import "orders";
+@import "pages";
+@import "pagination";
+@import "product_thumbnails";
+@import "products/fileupload";
+@import "products";
+@import "radfords";
+@import "sessions";
+@import "shared/flashes/thank_you";
+@import "suppliers";


### PR DESCRIPTION
Previously, all of the stylesheets were implicitly included into the main application stylesheet, which made it unclear as to which stylesheets were being included. All of the stylesheets are now explicitly imported into the main application stylesheet.

https://trello.com/c/2b5lGGHS

![](http://www.reactiongifs.com/r/14233995201878-anigif_enhanced-buzz-32695-1365622759-0.gif)