### PR TITLE
Remove sprockets requires

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,17 +1,3 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or vendor/assets/stylesheets of plugins, if any, can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the top of the
- * compiled file, but it's generally better to create a new file per style scope.
- *
- *= require_self
- *= require_tree .
- */
-
 @import "baskets";
 @import "bootstrap-fileupload.min";
 @import "bootstrap.min";


### PR DESCRIPTION
Previously, all of the stylesheets were explicitly imported into the application stylesheet, which rendered the `require_` statements in the application SASS obsolete. The two statements have been removed.

https://trello.com/c/2KGlddZ1

![](http://www.reactiongifs.com/r/tumblr_nj3ygtOZ5Q1qb5gkjo4_500.gif)