### PR TITLE
Add Bourbon to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.1.5'
 
 gem 'airbrake'
 gem 'aws-sdk'
+gem 'bourbon', '~> 3.2.1'
 gem 'coffee-rails'
 gem 'geocoder'
 gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
     aws-sdk-v1 (1.59.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
+    bourbon (3.2.4)
+      sass (~> 3.2)
+      thor
     builder (3.2.2)
     capybara (2.4.4)
       mime-types (>= 1.16)
@@ -227,6 +230,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake
   aws-sdk
+  bourbon (~> 3.2.1)
   capybara
   coffee-rails
   cucumber-rails


### PR DESCRIPTION
Previously, we were using an old version of Twitter Bootstrap as a base stylesheet for the application, which didn't support responsive web design. The Bourbon gem has been added to the Gemfile.

https://trello.com/c/GVTuzfB2

![](http://www.reactiongifs.com/r/gger.gif)