### PR TITLE
Import Bourbon styles

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,3 +1,5 @@
+@import "bourbon";
+
 @import "baskets";
 @import "bootstrap-fileupload.min";
 @import "bootstrap.min";


### PR DESCRIPTION
Previously, the Bourbon gem was bundled into the application and the styles were not being imported into the application's stylesheet, which made the inclusion of the gem pointless. The Bourbon styles have been imported into the application's stylesheet.

https://trello.com/c/kUtwLbmx

![](http://www.reactiongifs.com/r/ayfkm.gif)