### PR TITLE
Add Neat styles

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,4 +1,5 @@
 @import "bourbon";
+@import "neat";
 
 @import "baskets";
 @import "bootstrap-fileupload.min";


### PR DESCRIPTION
Previously, the Neat gem was bundled into the application and the styles were not being imported into the application's stylesheet, which made the inclusion of the gem pointless. The Neat styles should be imported into the application's stylesheet.

https://trello.com/c/gsQix8jA

![](http://www.reactiongifs.com/r/ln1.gif)