### PR TITLE
Add base grid settings

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,4 +1,5 @@
 @import "bourbon";
+@import "base/grid-settings";
 @import "neat";
 
 @import "baskets";


### PR DESCRIPTION
Previously, the grid settings from Neat were being used to define the layout of the application, which were not necessarily the best baseline.  The grid-settings from Bitters have been imported into the application's stylesheet.

https://trello.com/c/lpLh0JoL

![](http://www.reactiongifs.com/r/par.gif)