### PR TITLE
Import all Bitters styling

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,6 +1,7 @@
 @import "bourbon";
 @import "base/grid-settings";
 @import "neat";
+@import "base/base";
 
 @import "baskets";
 @import "bootstrap-fileupload.min";


### PR DESCRIPTION
Previously, we did not have a default baseline style defined, which meant that some of the application's base styles were at the mercy of the browser's defaults. The Bitters styles have been imported into the application's stylesheet.

https://trello.com/c/qxjFxUa9

![](http://www.reactiongifs.com/r/nmbp.gif)