### PR TITLE
Only allow positive product quantities

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -3,6 +3,8 @@ class LineItem < ActiveRecord::Base
   belongs_to :order
   belongs_to :product
 
+  validates :quantity, numericality: { greater_than: 0 }
+
   def total_price
     product.price * quantity
   end

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -40,5 +40,22 @@ module Features
 
       expect(page).to have_content("1 ×")
     end
+
+    it "only allows positive quantities" do
+      visit signin_path
+
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+
+      click_button "Sign in"
+
+      visit root_path
+
+      find("input[type=submit]").click
+
+      click_button "-"
+
+      expect(page).to have_content("1 ×")
+    end
   end
 end


### PR DESCRIPTION
Previously, a customer could reduce the quantity of products in their basket to a zero or negative amount, which caused Stripe to raise an exception. The basket has been modified to only allow line items with a positive quantity.

https://trello.com/c/cdmM1ENV

![](http://www.reactiongifs.com/r/yxd.gif)