### PR TITLE
Remove name and email restrictions

### DIFF
--- a/db/migrate/20150313111449_change_datatypes_on_orders_from_string_to_text.rb
+++ b/db/migrate/20150313111449_change_datatypes_on_orders_from_string_to_text.rb
@@ -1,0 +1,11 @@
+class ChangeDatatypesOnOrdersFromStringToText < ActiveRecord::Migration
+  def up
+    change_column :orders, :email, :text, limit: nil
+    change_column :orders, :name, :text, limit: nil
+  end
+
+  def down
+    change_column :orders, :email, :string
+    change_column :orders, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140819172705) do
+ActiveRecord::Schema.define(version: 20150313111449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,9 +42,9 @@ ActiveRecord::Schema.define(version: 20140819172705) do
   end
 
   create_table "orders", force: true do |t|
-    t.string   "name"
+    t.text     "name"
     t.text     "address"
-    t.string   "email"
+    t.text     "email"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "viewed",     default: false, null: false

--- a/features/step_definitions/orders_steps.rb
+++ b/features/step_definitions/orders_steps.rb
@@ -30,7 +30,12 @@ end
 When(/^I create the order$/) do
   new_order_page = NewOrderPage.new
   new_order_page.create(
-    name: 'Alphonso Quigley',
+    name: "rf;kqbewrfkl;bejqrgfkljqberfgkljqebrglfkjqberglfkjqbergfkjbqerlgkfjnb
+    qelfkjnqelkrbfjnqlekrjbqlerk glqkejrfglqkejrfg;qkebjrgf;kqbejrg;kqbejrfg;kjq
+    brqlejwrbfkjwhdbfkjlahbdsfghobehovbqaerljbawhvqklejfbvqlejfvlqjehrfgljqhwebf
+    kljqehbfrljqkwbefljkqwhberjklqhbewrfjlhqebrgfjophbeqrgfkljqhebrgljkqhbewrgfj
+    kqhbewrlfgjkhbqe;fpkgjhbqelrkgbqlekfbnq,mwebdfn,qkbf lqkejhbrfl;kqebhjfr;kpq
+    bej",
     address: '1 Test Street, Testerton TE5 7TE',
     email: 'alphonso.quigley@example.com'
   )


### PR DESCRIPTION
Previously, the order's were only allowed to have names and emails that had no more than 255 characters, which caused the database to throw an error when a name or email over 255 characters was submitted. The database columns have been updated so that they no longer have a limit.

https://trello.com/c/SaDxwosF

![](http://www.reactiongifs.com/r/hlit.gif)