### PR TITLE
Add button to product pages

### DIFF
--- a/app/assets/stylesheets/products.css.scss
+++ b/app/assets/stylesheets/products.css.scss
@@ -17,4 +17,8 @@ body.products {
       margin: 0 0 9px;
     }
   }
+
+  .add-to-basket {
+    float: right;
+  }
 }

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,7 +1,7 @@
 module PagesHelper
   def product_button(product)
     if signed_in?
-      render(partial: 'product_button', locals: { product: product })
+      render(partial: "shared/product_button", locals: { product: product })
     end
   end
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -9,6 +9,8 @@
 
   <p class="product-description"><%= @product.description %></p>
 
+  <%= product_button(@product) %>
+
   <% if signed_in? %>
     <div class="form-actions">
       <%= link_to('Back', products_path, class: 'btn') %>

--- a/app/views/shared/_product_button.html.erb
+++ b/app/views/shared/_product_button.html.erb
@@ -1,3 +1,3 @@
-<div>
+<div class="add-to-basket">
   <%= button_to("#{humanize_price product.price} - #{t('.add_to_basket')}", line_items_path(product_id: product)) %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,8 +49,6 @@ en:
   pages:
     home:
       title: Home
-    product_button:
-      add_to_basket: Add to Basket
   products:
     create: "You successfully created a product."
     destroy:
@@ -61,6 +59,8 @@ en:
   shared:
     navbar:
       orders: Orders
+    product_button:
+      add_to_basket: Add to Basket
   success_text: 'Well done'
   suppliers:
     update: "You successfully updated the supplier."

--- a/spec/features/line_items/new_spec.rb
+++ b/spec/features/line_items/new_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+module Features
+  describe "create from product page" do
+    let(:product) { Product.last }
+    let(:user) { FactoryGirl.create(:user) }
+
+    before { FactoryGirl.create(:product) }
+
+    it "shows the line item in the basket" do
+      visit signin_path
+
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+
+      click_button "Sign in"
+
+      visit product_url(product)
+
+      find("input[type=submit]").click
+
+      expect(page).to have_content("1 ×")
+    end
+  end
+end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -11,7 +11,7 @@ describe PagesHelper do
     before do
       allow(helper).to receive(:signed_in?).with(no_args).and_return(signed_in?)
       allow(helper).to receive(:render).with(
-        partial: 'product_button',
+        partial: "shared/product_button",
         locals: { product: product }
       ).once.and_return(partial)
     end


### PR DESCRIPTION
Previously, the "Add to Basket" button was only shown on the homepage, which was limiting where customers could add products to their basket.  The "Add to Basket" button is now shown on each product page.

https://trello.com/c/k7CfH66g

![](http://www.reactiongifs.com/r/hurr.gif)