### PR TITLE
Add a basket page

### DIFF
--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -2,7 +2,7 @@ class BasketsController < ApplicationController
   skip_before_filter :authenticate
 
   def show
-    @basket = Basket.find(params[:id])
+    @basket = Basket.find(session["basket_id"])
   rescue ActiveRecord::RecordNotFound
     redirect_to shop_url, alert: t('baskets.show.alert')
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,8 @@ en:
       notice: Your basket is currently empty.
     show:
       alert: Invalid basket.
+      heading: "Your Basket"
+      title: "Your Basket"
   error_text: 'Oh snap'
   events:
     not_found: "We couldn't find the event you were looking for."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Radfords::Application.routes.draw do
+  resource :basket
+
   resources :orders
-  resources :baskets
   resources :events do
     member do
       get :delete

--- a/features/support/pages/basket_page.rb
+++ b/features/support/pages/basket_page.rb
@@ -14,6 +14,6 @@ class BasketPage
   end
 
   def visit_page
-    visit "/baskets/foo"
+    visit "/basket"
   end
 end

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -2,23 +2,31 @@ require 'spec_helper'
 
 describe BasketsController do
   describe 'GET "show"' do
+    let(:basket) { double("Basket") }
+    let(:basket_id) { "1" }
+
+    before do
+      allow(Basket).to receive(:find).with(basket_id).and_return(basket)
+    end
+
     it 'finds the basket' do
-      basket = Basket.new
-      allow(Basket).to receive(:find).with("1").and_return(basket)
-      get :show, id: '1'
-      expect(assigns(:basket)).to be basket
+      get :show, nil, basket_id: basket_id
+      expect(assigns(:basket)).to be(basket)
     end
 
     context 'when a basket can\'t be found' do
+      before do
+        allow(Basket).to receive(:find).with(basket_id).
+          and_raise(ActiveRecord::RecordNotFound)
+      end
+
       it 'redirects to the shop' do
-        allow(Basket).to receive(:find).with("1").and_raise(ActiveRecord::RecordNotFound)
-        get :show, id: '1'
-        expect(response).to redirect_to shop_url
+        get :show, nil, basket_id: basket_id
+        expect(response).to redirect_to(shop_url)
       end
 
       it 'alerts the user' do
-        allow(Basket).to receive(:find).with("1").and_raise(ActiveRecord::RecordNotFound)
-        get :show, id: '1'
+        get :show, nil, basket_id: basket_id
         expect(flash[:alert]).to eql I18n.t('baskets.show.alert')
       end
     end


### PR DESCRIPTION
Previously, there was no way for a customer to see their basket without going to the home page, which was proving to be confusing to the customer. A basket page has been added to see the basket.

https://trello.com/c/lWhrwi5j

![](http://www.reactiongifs.com/r/pamyup.gif)