### PR TITLE
Show empty basket message

### DIFF
--- a/app/assets/stylesheets/baskets.css.scss
+++ b/app/assets/stylesheets/baskets.css.scss
@@ -41,3 +41,10 @@
     margin-bottom: 0;
   }
 }
+
+.empty {
+  background: $light-gray;
+  margin-bottom: 18px;
+  padding: 20px;
+  text-align: center;
+}

--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -2,9 +2,7 @@ class BasketsController < ApplicationController
   skip_before_filter :authenticate
 
   def show
-    @basket = Basket.find(session["basket_id"])
-  rescue ActiveRecord::RecordNotFound
-    redirect_to shop_url, alert: t('baskets.show.alert')
+    @basket = FindBasket.call(id: session["basket_id"])
   end
 
   def destroy

--- a/app/models/find_basket.rb
+++ b/app/models/find_basket.rb
@@ -1,0 +1,5 @@
+class FindBasket
+  def self.call(options)
+    Basket.where(options).first || MissingBasket.new
+  end
+end

--- a/app/models/missing_basket.rb
+++ b/app/models/missing_basket.rb
@@ -1,0 +1,5 @@
+class MissingBasket
+  def to_partial_path
+    "empty_basket"
+  end
+end

--- a/app/views/baskets/_empty_basket.html.erb
+++ b/app/views/baskets/_empty_basket.html.erb
@@ -1,0 +1,3 @@
+<div class="empty">
+  <%= t(".empty") %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
       title: Basket
     destroy:
       notice: Your basket is currently empty.
+    empty_basket:
+      empty: "Your basket is empty."
     show:
       alert: Invalid basket.
       heading: "Your Basket"

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -3,8 +3,8 @@ Feature: Baskets
   Scenario:
     Given I don't have a basket
     When I view the basket
-    Then I see the "Shop" page
-    And I see an "Invalid basket" alert
+    Then I see the "Your Basket" page
+    And I see a "Your basket is empty" message
 
   Scenario:
     Given I am signed in

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -6,29 +6,13 @@ describe BasketsController do
     let(:basket_id) { "1" }
 
     before do
-      allow(Basket).to receive(:find).with(basket_id).and_return(basket)
+      allow(FindBasket).to receive(:call).with(id: basket_id).
+        and_return(basket)
     end
 
     it 'finds the basket' do
       get :show, nil, basket_id: basket_id
       expect(assigns(:basket)).to be(basket)
-    end
-
-    context 'when a basket can\'t be found' do
-      before do
-        allow(Basket).to receive(:find).with(basket_id).
-          and_raise(ActiveRecord::RecordNotFound)
-      end
-
-      it 'redirects to the shop' do
-        get :show, nil, basket_id: basket_id
-        expect(response).to redirect_to(shop_url)
-      end
-
-      it 'alerts the user' do
-        get :show, nil, basket_id: basket_id
-        expect(flash[:alert]).to eql I18n.t('baskets.show.alert')
-      end
     end
   end
 

--- a/spec/models/find_basket_spec.rb
+++ b/spec/models/find_basket_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+describe FindBasket do
+  describe ".call" do
+    subject { FindBasket.call(options) }
+
+    let(:basket) { double("Basket") }
+    let(:missing_basket) { double("MissingBasket") }
+    let(:options) { { id: "1" } }
+
+    before do
+      allow(Basket).to receive(:where).with(options).and_return([basket])
+      allow(MissingBasket).to receive(:new).and_return(missing_basket)
+    end
+
+    it "returns the found basket" do
+      expect(subject).to be(basket)
+    end
+
+    context "when a basket can't be found" do
+      let(:basket) { nil }
+
+      it "returns a missing basket" do
+        expect(subject).to be(missing_basket)
+      end
+    end
+  end
+end

--- a/spec/models/missing_basket_spec.rb
+++ b/spec/models/missing_basket_spec.rb
@@ -1,0 +1,9 @@
+require "spec_helper"
+
+describe MissingBasket do
+  describe "#to_partial_path" do
+    it "returns 'empty_basket'" do
+      expect(subject.to_partial_path).to eql("empty_basket")
+    end
+  end
+end


### PR DESCRIPTION
Previously, when the visitor's basket was empty, an empty table was shown, which was not telling the visitor that their basket had nothing in it. The basket page has been updated to include a message when the basket is empty.

https://trello.com/c/LbVYevSe

![](http://www.reactiongifs.com/r/9021orly.gif)