### PR TITLE
Show empty basket message

### DIFF
--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -2,7 +2,7 @@ class BasketsController < ApplicationController
   skip_before_filter :authenticate
 
   def show
-    @basket = FindBasket.call(id: session["basket_id"])
+    @basket = BasketDecorator.new(FindBasket.call(id: session["basket_id"]))
   end
 
   def destroy

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -9,7 +9,7 @@ class LineItemsController < ApplicationController
 
   def destroy
     item.destroy
-    redirect_to root_url
+    redirect_to basket_url
   end
 
   def update

--- a/app/models/basket_decorator.rb
+++ b/app/models/basket_decorator.rb
@@ -1,0 +1,39 @@
+class BasketDecorator
+  def initialize(basket)
+    @basket = basket
+  end
+
+  def self.model_name
+    Basket.model_name
+  end
+
+  def line_items
+    @basket.line_items
+  end
+
+  def to_partial_path
+    all_partials.first
+  end
+
+  def total_price
+    @basket.total_price
+  end
+
+  private
+
+  def all_partials
+    basket_partials.push(default_partial)
+  end
+
+  def basket_partials
+    line_items.map { partial_path }
+  end
+
+  def default_partial
+    "empty_basket"
+  end
+
+  def partial_path
+    @basket.to_partial_path
+  end
+end

--- a/app/models/missing_basket.rb
+++ b/app/models/missing_basket.rb
@@ -1,5 +1,5 @@
 class MissingBasket
-  def to_partial_path
-    "empty_basket"
+  def line_items
+    []
   end
 end

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -22,3 +22,12 @@ Feature: Baskets
     When I add the product to my basket
     Then I see the "Home" page
     And I see the product in my basket twice
+
+  Scenario: Remove all items from the basket
+    Given I am signed in
+    And a product exists
+    And I have the product in my basket
+    And I am viewing my basket
+    When I remove the product from my basket
+    Then I see the "Your Basket" page
+    And I see a "Your basket is empty" message

--- a/features/step_definitions/baskets_steps.rb
+++ b/features/step_definitions/baskets_steps.rb
@@ -5,6 +5,10 @@ Given(/^I am on the "Shop" page$/) do
   shop_page.visit_page
 end
 
+Given(/^I am viewing my basket$/) do
+  visit(basket_url)
+end
+
 Given(/^I don't have a basket$/) do
   expect(Basket.all.count).to be_zero
 end
@@ -20,6 +24,10 @@ end
 When(/^I empty my basket$/) do
   basket_page = BasketPage.new
   basket_page.empty
+end
+
+When(/^I remove the product from my basket$/) do
+  click_link("Remove")
 end
 
 When(/^I view the basket$/) do

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -4,15 +4,18 @@ describe BasketsController do
   describe 'GET "show"' do
     let(:basket) { double("Basket") }
     let(:basket_id) { "1" }
+    let(:decorator) { double("BasketDecorator") }
 
     before do
+      allow(BasketDecorator).to receive(:new).with(basket).
+        and_return(decorator)
       allow(FindBasket).to receive(:call).with(id: basket_id).
         and_return(basket)
     end
 
-    it 'finds the basket' do
+    it "is successful" do
       get :show, nil, basket_id: basket_id
-      expect(assigns(:basket)).to be(basket)
+      expect(response).to be_success
     end
   end
 

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -34,7 +34,7 @@ describe LineItemsController do
 
     it "redirects to the home page" do
       delete :destroy, params
-      expect(response).to redirect_to root_url
+      expect(response).to redirect_to basket_url
     end
   end
 

--- a/spec/models/basket_decorator_spec.rb
+++ b/spec/models/basket_decorator_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe BasketDecorator do
+  let(:decorator) { BasketDecorator.new(basket) }
+
+  describe ".model_name" do
+    let(:model_name) { double("ActiveModel::Name") }
+
+    before { allow(Basket).to receive(:model_name).and_return(model_name) }
+
+    it "returns the model name of the basket" do
+      expect(BasketDecorator.model_name).to be(model_name)
+    end
+  end
+
+  describe "#line_items" do
+    let(:basket) { double("Basket", line_items: line_items) }
+    let(:line_items) { [] }
+
+    it "returns the basket's line items" do
+      expect(decorator.line_items).to be(line_items)
+    end
+  end
+
+  describe "#to_partial_path" do
+    subject { decorator.to_partial_path }
+
+    let(:line_items) { [] }
+    let(:partial_path) { "baskets/basket" }
+
+    let(:basket) do
+      double("Basket", line_items: line_items, to_partial_path: partial_path)
+    end
+
+    it "returns 'empty_basket'" do
+      expect(subject).to eql("empty_basket")
+    end
+
+    context "when the basket has items" do
+      let(:line_items) { [double("LineItem")] }
+
+      it "returns the basket's partial path" do
+        expect(subject).to eql(partial_path)
+      end
+    end
+  end
+
+  describe "#total_price" do
+    let(:basket) { double("Basket", total_price: total_price) }
+    let(:total_price) { double("Money") }
+
+    it "returns the basket's total price" do
+      expect(decorator.total_price).to be(total_price)
+    end
+  end
+end

--- a/spec/models/missing_basket_spec.rb
+++ b/spec/models/missing_basket_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
 describe MissingBasket do
-  describe "#to_partial_path" do
-    it "returns 'empty_basket'" do
-      expect(subject.to_partial_path).to eql("empty_basket")
+  describe "#line_items" do
+    it "returns an empty array" do
+      expect(MissingBasket.new.line_items).to eql([])
     end
   end
 end


### PR DESCRIPTION
Previously, when the visitor's basket was empty, an empty table was shown, which was not telling the visitor that their basket had nothing in it. The basket page now includes a message when the basket is empty.

https://trello.com/c/L4SUzTL7

![](http://www.reactiongifs.com/r/jfp.gif)