### PR TITLE
Link to the basket

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,6 +18,10 @@
       <li>
         <%= link_to "Contact us", contact_path %>
       </li>
+
+      <% if signed_in? %>
+        <li><%= link_to(t(".basket"), basket_path) %></li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 
-<%= form_for :session, url: sessions_path do |f| %>
+<%= form_for :session, html: { id: "new_session" }, url: sessions_path do |f| %>
   <div class="control-group">
     <%= f.label :email, class: 'control-label' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@ en:
     create:
       notice: Shipment notification email sent
   info_text: 'Heads up'
+  layouts:
+    header:
+      basket: "Basket"
   mailer:
     order_received:
       subject: Order confirmation for order %{id}

--- a/spec/features/layouts/header_spec.rb
+++ b/spec/features/layouts/header_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "application header" do
+  let(:home_page) { HomePage.new }
+  let(:signin_page) { SigninPage.new(user.email, user.password) }
+  let(:user) { FactoryGirl.create(:user) }
+
+  before { sign_in }
+
+  it "navigates to 'Your Basket'" do
+    home_page.visit
+    home_page.go_to_basket
+
+    expect(page).to have_title "Your Basket"
+  end
+
+  def sign_in
+    signin_page.visit
+    signin_page.sign_in
+  end
+end

--- a/spec/support/pages/home_page.rb
+++ b/spec/support/pages/home_page.rb
@@ -1,0 +1,11 @@
+class HomePage
+  include Capybara::DSL
+
+  def go_to_basket
+    click_link "Basket"
+  end
+
+  def visit
+    super("/")
+  end
+end

--- a/spec/support/pages/signin_page.rb
+++ b/spec/support/pages/signin_page.rb
@@ -15,6 +15,10 @@ class SigninPage
     click_button 'Sign in'
   end
 
+  def visit
+    super("/signin")
+  end
+
   private
 
   attr_reader :email, :password


### PR DESCRIPTION
Previously, visitors could only access their basket if they knew the URL of the page, which meant that most users could not view their basket.  Added a link to the site navigation that links to the basket.

https://trello.com/c/TymVAKiD

![](http://www.reactiongifs.com/r/jcn.gif)