### PR TITLE
Show the item count in the basket

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
   protect_from_forgery
-  before_filter :authenticate
+  before_filter :authenticate, :find_basket
 
   def authenticate
     deny_access unless signed_in?
+  end
+
+  def find_basket
+    @basket = BasketDecorator.new(FindBasket.call(id: session["basket_id"]))
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,6 @@ class PagesController < ApplicationController
   skip_before_filter :authenticate
 
   def home
-    @basket = basket
     @events = Event.limit(3)
 
     if session[:order_id]
@@ -23,12 +22,4 @@ class PagesController < ApplicationController
   end
 
   def contact; end
-
-  private
-
-  def basket
-    Basket.find(session[:basket_id])
-  rescue ActiveRecord::RecordNotFound
-    NullBasket.new
-  end
 end

--- a/app/models/basket_decorator.rb
+++ b/app/models/basket_decorator.rb
@@ -7,6 +7,10 @@ class BasketDecorator
     Basket.model_name
   end
 
+  def item_count
+    item_quantities.inject(0) { |quantity, acc| acc + quantity }
+  end
+
   def line_items
     @basket.line_items
   end
@@ -31,6 +35,10 @@ class BasketDecorator
 
   def default_partial
     "empty_basket"
+  end
+
+  def item_quantities
+    line_items.map(&:quantity)
   end
 
   def partial_path

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,7 +20,7 @@
       </li>
 
       <% if signed_in? %>
-        <li><%= link_to(t(".basket"), basket_path) %></li>
+        <li><%= link_to(t(".basket", item_count: @basket.item_count), basket_path) %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
   info_text: 'Heads up'
   layouts:
     header:
-      basket: "Basket"
+      basket: "Basket (%{item_count})"
   mailer:
     order_received:
       subject: Order confirmation for order %{id}

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,4 +14,21 @@ describe ApplicationController do
       end
     end
   end
+
+  describe "#find_basket" do
+    let(:basket) { double("Basket") }
+    let(:decorated_basket) { double("BasketDecorator") }
+    let(:id) { "1" }
+
+    before do
+      session["basket_id"] = id
+      allow(BasketDecorator).to receive(:new).with(basket).
+        and_return(decorated_basket)
+      allow(FindBasket).to receive(:call).with(id: id).and_return(basket)
+    end
+
+    it "returns the current user's basket" do
+      expect(controller.find_basket).to be decorated_basket
+    end
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -6,18 +6,6 @@ describe PagesController do
   end
 
   describe "GET 'home'" do
-    let(:basket) { double("Basket") }
-    let(:basket_id) { 2 }
-    let(:null_basket) { double("NullBasket") }
-    let(:session_basket) { basket_id }
-
-    before do
-      allow(Basket).to receive(:find).with(basket_id).and_return(basket)
-      allow(Basket).to receive(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
-      allow(NullBasket).to receive(:new).and_return(null_basket)
-      session[:basket_id] = session_basket
-    end
-
     it "should be successful" do
       get 'home'
       expect(response).to be_success
@@ -30,11 +18,6 @@ describe PagesController do
       get :home
 
       expect(assigns(:events)).to eql [event]
-    end
-
-    it "gets the current basket" do
-      get :home
-      expect(assigns :basket).to be(basket)
     end
 
     context 'when there is an order ID in the session' do
@@ -54,15 +37,6 @@ describe PagesController do
       it 'removes the order ID from the session' do
         get :home
         expect(session[:order_id]).to be_nil
-      end
-    end
-
-    context "when there is no basket ID in the session" do
-      let(:session_basket) { nil }
-
-      it "assigns a null basket" do
-        get :home
-        expect(assigns(:basket)).to be(null_basket)
       end
     end
   end

--- a/spec/models/basket_decorator_spec.rb
+++ b/spec/models/basket_decorator_spec.rb
@@ -13,6 +13,17 @@ describe BasketDecorator do
     end
   end
 
+  describe "#item_count" do
+    let(:basket) { double("Basket", line_items: line_items) }
+    let(:item_1) { double("LineItem", quantity: 2) }
+    let(:item_2) { double("LineItem", quantity: 1) }
+    let(:line_items) { [item_1, item_2] }
+
+    it "returns the total quantity of line items" do
+      expect(decorator.item_count).to eql 3
+    end
+  end
+
   describe "#line_items" do
     let(:basket) { double("Basket", line_items: line_items) }
     let(:line_items) { [] }

--- a/spec/support/pages/home_page.rb
+++ b/spec/support/pages/home_page.rb
@@ -2,7 +2,7 @@ class HomePage
   include Capybara::DSL
 
   def go_to_basket
-    click_link "Basket"
+    click_link "Basket (0)"
   end
 
   def visit


### PR DESCRIPTION
Previously, there was no way for a customer to see how many items were in their basket, which was proving to be confusing to the customer. The item count has been added to the basket link in the main navigation menu.

https://trello.com/c/rN7qFsl0

![](http://www.reactiongifs.com/r/oooh.gif)