### PR TITLE
Redirect to "Your Basket" after emptying basket

### DIFF
--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -9,6 +9,6 @@ class BasketsController < ApplicationController
     @basket = current_basket
     @basket.destroy
     session[:basket_id] = nil
-    redirect_to shop_url, notice: t('baskets.destroy.notice')
+    redirect_to basket_url, notice: t("baskets.destroy.notice")
   end
 end

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -11,7 +11,7 @@ Feature: Baskets
     And a product exists
     And I have the product in my basket
     When I empty my basket
-    Then I see the "Shop" page
+    Then I see the "Your Basket" page
     And I see a "Your basket is currently empty" notice
 
   Scenario:

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -23,7 +23,7 @@ describe BasketsController do
     it 'redirects to the shop' do
       allow(Basket).to receive(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
       delete :destroy, id: '1'
-      expect(response).to redirect_to shop_url
+      expect(response).to redirect_to basket_url
     end
   end
 end


### PR DESCRIPTION
Previously, when a user emptied their basket they were redirected to the homepage, which was confusing to the user. When the user empties their basket they are redirected to their basket page.

https://trello.com/c/s8itZ5fw

![](http://www.reactiongifs.com/r/diint.gif)