### PR TITLE
Add product links to the basket

### DIFF
--- a/app/views/baskets/_basket.html.erb
+++ b/app/views/baskets/_basket.html.erb
@@ -24,7 +24,7 @@
           method: :patch
         ) %></td>
 
-        <td class="description"><%= item.product.title %></td>
+        <td class="description"><%= link_to(item.product.title, product_path(item.product)) %></td>
 
         <td class="item-price"><%= humanize_price(item.total_price) %></td>
 

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -31,3 +31,11 @@ Feature: Baskets
     When I remove the product from my basket
     Then I see the "Your Basket" page
     And I see a "Your basket is empty" message
+
+  Scenario: Link to product page
+    Given I am signed in
+    And a product exists
+    And I have the product in my basket
+    And I am viewing my basket
+    When I click on the product
+    Then I see the product's page

--- a/features/step_definitions/baskets_steps.rb
+++ b/features/step_definitions/baskets_steps.rb
@@ -21,6 +21,11 @@ When(/^I add the product to my basket$/) do
   shop_page.add_to_basket(product)
 end
 
+When(/^I click on the product$/) do
+  basket_page = BasketPage.new
+  basket_page.view_product
+end
+
 When(/^I empty my basket$/) do
   basket_page = BasketPage.new
   basket_page.empty
@@ -40,4 +45,9 @@ end
 Then(/^I see the product in my basket twice$/) do
   basket_page = BasketPage.new
   expect(basket_page).to have_product_twice
+end
+
+Then(/^I see the product's page$/) do
+  product = Product.last
+  expect(page).to have_title product.title
 end

--- a/features/support/pages/basket_page.rb
+++ b/features/support/pages/basket_page.rb
@@ -16,4 +16,14 @@ class BasketPage
   def visit_page
     visit "/basket"
   end
+
+  def view_product
+    click_link product.title
+  end
+
+  private
+
+  def product
+    Product.last
+  end
 end


### PR DESCRIPTION
Previously, the products in the basket were just text, which made it difficult for users to see information about a product from the basket.  A link to each product has been added to the basket.

https://trello.com/c/xsmYtMTl

![](http://www.reactiongifs.com/r/dtdk.gif)