### PR TITLE
Remove Campfire in favor of Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,10 @@ cache:
 language:
   - ruby
 notifications:
-  campfire:
-    on_failure:
-      - always
-    on_success:
-      - change
-    template:
-      - '(%{branch} - %{author}): %{message} - %{build_url}'
   email:
     - false
+  slack:
+    secure: GQ3iBioeING+mB1H2NiWURymJmeXk+1Y6A0k2ZcCBsAYnBx15OPuu6svXtSHMo0cHX2dN9PbaVUtD0WiAf/JXGZ1rsiaNecsio/ZBWWQ+KEIlEPe485stHv5JoUfGyBvsUWGYBnCqEhW0KFahL8Ny3WUIIkqrg+X8HKozYrpITU=
 rvm:
   - 2.1.2
 addons:


### PR DESCRIPTION
We don't need a placeholder for Slack because we'll typically add it using the CLI:

    travis encrypt "thoughtbot:123abc" --add notifications.slack

http://blog.travis-ci.com/2014-03-13-slack-notifications/

![](http://www.reactiongifs.com/r/mny2.gif)