### PR TITLE
Reorder "Payment" fields on "Checkout" page

### DIFF
--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -91,17 +91,6 @@
     </div>
 
     <div class="field">
-      <%= label_tag(nil, t(".cvc")) %>
-      <%= text_field_tag(
-        nil,
-        nil,
-        class: "card-cvc",
-        data: { stripe: "cvc" },
-        placeholder: t(".cvc")
-      ) %>
-    </div>
-
-    <div class="field">
       <%= label_tag(nil, t(".expiration")) %>
 
       <div class="select-group">
@@ -120,6 +109,17 @@
           placeholder: t(".exp_year")
         ) %>
       </div>
+    </div>
+
+    <div class="field">
+      <%= label_tag(nil, t(".cvc")) %>
+      <%= text_field_tag(
+        nil,
+        nil,
+        class: "card-cvc",
+        data: { stripe: "cvc" },
+        placeholder: t(".cvc")
+      ) %>
     </div>
   </div>
 


### PR DESCRIPTION
Previously, the “Payment” fields on the “Checkout” page were listed: “Card number”; “CVV”; “Expiry”, which was not in an order related to an actual credit/debit card and provided an awkward experience to the customer. The fields have been ordered: “Card number”, “Expiry”, “CVV”.

https://trello.com/c/QkN0czvJ