### PR TITLE
Rename "CVV" field to "CVV (Security code)"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
       card_number: Card number
       create: "Place my order"
       customer_information: "Customer Information"
-      cvc: "CVV"
+      cvc: "CVV (Security code)"
       delivery_address: "Delivery Address"
       email: "Email"
       exp_month: "MM"


### PR DESCRIPTION
Previously, the security code field on the “New order” page had the label “CVV”, which was not clear to the customer. The label has been updated to “CVV (Security code)”.

https://trello.com/c/9zYskgC5

![](http://www.reactiongifs.com/r/cpbp.gif)