### PR TITLE
Keep line items in order

### DIFF
--- a/app/models/basket_decorator.rb
+++ b/app/models/basket_decorator.rb
@@ -12,7 +12,7 @@ class BasketDecorator
   end
 
   def line_items
-    @basket.line_items
+    @basket.line_items.by_created_at
   end
 
   def to_partial_path

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -5,6 +5,8 @@ class LineItem < ActiveRecord::Base
 
   validates :quantity, numericality: { greater_than: 0 }
 
+  scope :by_created_at, -> { order(:created_at) }
+
   def total_price
     product.price * quantity
   end

--- a/app/models/missing_basket.rb
+++ b/app/models/missing_basket.rb
@@ -1,5 +1,5 @@
 class MissingBasket
   def line_items
-    []
+    LineItem.none
   end
 end

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -2,60 +2,72 @@ require "spec_helper"
 
 module Features
   describe "edit line item" do
-    let(:user) { FactoryGirl.create :user }
-
-    before { FactoryGirl.create :product }
-
     it "increases the item's quantity" do
-      visit signin_path
+      create :product
+      sign_in
+      add_products_to_basket
 
-      fill_in("Email", with: user.email)
-      fill_in("Password", with: user.password)
+      basket_page.visit
+      basket_page.increase_item_quantity
 
-      click_button "Sign in"
-
-      visit root_path
-
-      find("input[type=submit]").click
-
-      click_button "+"
-
-      expect(page).to have_content("2 ×")
+      expect(basket_page).to have_content("2 ×")
     end
 
     it "decreases the item's quantity" do
-      visit signin_path
+      create :product
+      sign_in
+      add_products_to_basket
 
-      fill_in("Email", with: user.email)
-      fill_in("Password", with: user.password)
+      basket_page.visit
+      basket_page.increase_item_quantity
+      basket_page.decrease_item_quantity
 
-      click_button "Sign in"
-
-      visit root_path
-
-      find("input[type=submit]").click
-
-      click_button "+"
-      click_button "-"
-
-      expect(page).to have_content("1 ×")
+      expect(basket_page).to have_content("1 ×")
     end
 
     it "only allows positive quantities" do
-      visit signin_path
+      create :product
+      sign_in
+      add_products_to_basket
 
-      fill_in("Email", with: user.email)
-      fill_in("Password", with: user.password)
+      basket_page.visit
+      basket_page.decrease_item_quantity
 
-      click_button "Sign in"
+      expect(basket_page).to have_content("1 ×")
+    end
 
-      visit root_path
+    it "keeps the items in the correct order" do
+      create_products
+      sign_in
+      add_products_to_basket
 
-      find("input[type=submit]").click
+      basket_page.visit
+      basket_page.increase_item_quantity
 
-      click_button "-"
+      expect(basket_page).to have_items_in_created_at_order
+    end
 
-      expect(page).to have_content("1 ×")
+    def add_products_to_basket
+      Product.all.each do |product|
+        page = ProductPage.new(product: product)
+        page.visit
+        page.add_to_basket
+      end
+    end
+
+    def basket_page
+      @basket_page ||= BasketPage.new
+    end
+
+    def create_products
+      create(:product, title: "Plum Jam")
+      create(:product, title: "Rhubarb and Ginger Jam")
+    end
+
+    def sign_in
+      page = NewSessionPage.new
+      page.visit
+      page.sign_in
     end
   end
 end

--- a/spec/models/basket_decorator_spec.rb
+++ b/spec/models/basket_decorator_spec.rb
@@ -14,10 +14,14 @@ describe BasketDecorator do
   end
 
   describe "#item_count" do
-    let(:basket) { double("Basket", line_items: line_items) }
+    let(:basket) { double("Basket") }
     let(:item_1) { double("LineItem", quantity: 2) }
     let(:item_2) { double("LineItem", quantity: 1) }
     let(:line_items) { [item_1, item_2] }
+
+    before do
+      allow(decorator).to receive(:line_items).and_return(line_items)
+    end
 
     it "returns the total quantity of line items" do
       expect(decorator.item_count).to eql 3
@@ -25,10 +29,14 @@ describe BasketDecorator do
   end
 
   describe "#line_items" do
-    let(:basket) { double("Basket", line_items: line_items) }
+    let(:relation) do
+      double("ActiveRecord::Relation", by_created_at: line_items)
+    end
+
+    let(:basket) { double("Basket", line_items: relation) }
     let(:line_items) { [] }
 
-    it "returns the basket's line items" do
+    it "returns the basket's line items ordered by creation time" do
       expect(decorator.line_items).to be(line_items)
     end
   end
@@ -40,7 +48,11 @@ describe BasketDecorator do
     let(:partial_path) { "baskets/basket" }
 
     let(:basket) do
-      double("Basket", line_items: line_items, to_partial_path: partial_path)
+      double("Basket", to_partial_path: partial_path)
+    end
+
+    before do
+      allow(decorator).to receive(:line_items).and_return(line_items)
     end
 
     it "returns 'empty_basket'" do

--- a/spec/models/missing_basket_spec.rb
+++ b/spec/models/missing_basket_spec.rb
@@ -2,8 +2,14 @@ require "spec_helper"
 
 describe MissingBasket do
   describe "#line_items" do
-    it "returns an empty array" do
-      expect(MissingBasket.new.line_items).to eql([])
+    let(:none) { double("ActiveRecord::Relation") }
+
+    before do
+      allow(LineItem).to receive(:none).and_return(none)
+    end
+
+    it "returns an 'None' relation" do
+      expect(MissingBasket.new.line_items).to be none
     end
   end
 end

--- a/spec/support/pages/basket_page.rb
+++ b/spec/support/pages/basket_page.rb
@@ -1,0 +1,29 @@
+class BasketPage
+  include Capybara::DSL
+
+  def decrease_item_quantity
+    first(:button, "-").click
+  end
+
+  def has_items_in_created_at_order?
+    body.index(first_product.title) < body.index(last_product.title)
+  end
+
+  def increase_item_quantity
+    first(:button, "+").click
+  end
+
+  def visit
+    super "/basket"
+  end
+
+  private
+
+  def first_product
+    Product.first
+  end
+
+  def last_product
+    Product.last
+  end
+end

--- a/spec/support/pages/product_page.rb
+++ b/spec/support/pages/product_page.rb
@@ -1,17 +1,17 @@
 class ProductPage
   include Capybara::DSL
 
+  attr_reader :product
+
+  def initialize(product: Product.first)
+    @product = product
+  end
+
   def add_to_basket
     click_button "Add to Basket"
   end
 
   def visit
     super "/products/#{product.id}"
-  end
-
-  private
-
-  def product
-    Product.last
   end
 end


### PR DESCRIPTION
Previously, when a user adjusted the quantity of an item in their basket, the order of the items changed, which was confusing for the customer. The basket now displays items in the order in which they were created.

https://trello.com/c/DHwQTnou

![](http://www.reactiongifs.com/r/towlie.gif)