### PR TITLE
Remove “Apt, suite, etc.” field

### DIFF
--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -39,15 +39,6 @@
       </div>
 
       <div class="field">
-        <%= f.label(:address_line_2) %>
-        <%= f.text_field(
-          :address_line_2,
-          data: { stripe: 'address-line2' },
-          placeholder: t(".address_line_2")
-        ) %>
-      </div>
-
-      <div class="field">
         <%= f.label(:address_city) %>
         <%= f.text_field(
           :address_city,

--- a/features/support/pages/new_order_page.rb
+++ b/features/support/pages/new_order_page.rb
@@ -7,7 +7,6 @@ class NewOrderPage
     fill_form(
       :order,
       "Address" => "1 Test Street",
-      "Apt, suite, etc." => "Testerton",
       "City" => "Testington",
       "Postal code" => "TE5 7TE",
       "County" => "Testshire",


### PR DESCRIPTION
Previously, there was an “Apt, suite, etc.” field on the “New order” page, which was proving to be confusing to customers. The field has been removed.

https://trello.com/c/k2s2rGPJ

![](http://www.reactiongifs.com/r/msty.gif)