### PR TITLE
Redirect to the basket after adding a product

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -4,7 +4,7 @@ class LineItemsController < ApplicationController
   def create
     @basket = current_basket
     @basket.add_product(product.id).save
-    redirect_to root_url
+    redirect_to basket_url
   end
 
   def destroy

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -14,13 +14,13 @@ Feature: Baskets
     Then I see the "Your Basket" page
     And I see a "Your basket is currently empty" notice
 
-  Scenario:
+  Scenario: Add a product to my basket
     Given I am signed in
     And a product exists
     And I have the product in my basket
     And I am on the "Shop" page
     When I add the product to my basket
-    Then I see the "Home" page
+    Then I see the "Your Basket" page
     And I see the product in my basket twice
 
   Scenario: Remove all items from the basket

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -3,20 +3,18 @@ require 'spec_helper'
 describe LineItemsController do
   describe 'POST "create"' do
     let(:basket) { double(Basket, save: nil) }
-    let(:basket_url) { '/basket/1' }
     let(:product) { double(Product, id: product_id) }
     let(:product_id) { '1' }
 
     before do
       allow(basket).to receive(:add_product).with(product_id).and_return(basket)
       allow(controller).to receive(:current_basket).and_return(basket)
-      allow(controller).to receive(:url_for).with(basket).and_return(basket_url)
       allow(Product).to receive(:find).with(product_id).and_return(product)
     end
 
     it 'redirects to the saved basket' do
       post :create, product_id: product_id
-      expect(response).to redirect_to(root_url)
+      expect(response).to redirect_to(basket_url)
     end
   end
 


### PR DESCRIPTION
Previously, when a customer added a product to their basket they were being redirected to the homepage, which was proving to be confusing. The controller has been updated to redirect customers to their basket when they add a new product to it.

https://trello.com/c/pG11zCFg

![](http://www.reactiongifs.com/r/sbtlf.gif)