### PR TITLE
Redirect to the basket after changing quantity

### DIFF
--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -14,7 +14,7 @@ class LineItemsController < ApplicationController
 
   def update
     item.update_attributes item_params
-    redirect_to root_url
+    redirect_to basket_url
   end
 
   private

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -54,7 +54,7 @@ describe LineItemsController do
 
     it "redirects to the home page" do
       put :update, params
-      expect(response).to redirect_to root_url
+      expect(response).to redirect_to basket_url
     end
   end
 end


### PR DESCRIPTION
Previously, when a customer changed the quantity of a product to their basket they were being redirected to the homepage, which was proving to be confusing. The controller has been updated to redirect customers to their basket when they change the quantity of a product.

https://trello.com/c/DkFbG2df

![](http://www.reactiongifs.com/r/awk.gif)