### PR TITLE
Don't show the basket on the homepage

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,5 @@
 <% content_for(:title, t('.title')) %>
 
-<%= render_basket(@basket) %>
-
 <ul class="product-thumbnails">
   <%= render(
     partial: 'product_thumbnails',


### PR DESCRIPTION
Previously, the basket was shown on the homepage and on it’s own page, which was causing confusion for customers when they were trying to navigate around the site. The basket has been removed from the homepage.

https://trello.com/c/O1dZKYtM

![](http://www.reactiongifs.com/r/whowut.gif)