### PR TITLE
Link to suppliers

### DIFF
--- a/app/views/pages/outlets.html.erb
+++ b/app/views/pages/outlets.html.erb
@@ -78,7 +78,7 @@
         </p>
 
         <% if supplier.website %>
-          <p><%= supplier.website %></p>
+          <p><%= link_to(supplier.website, supplier.website) %></p>
         <% end %>
 
         <p class="telephone">


### PR DESCRIPTION
Previously, supplier websites on the "Suppliers" page were not links, which made it difficult for customers to find out more information about our suppliers. The links have been made clickable.

https://trello.com/c/fJdkNPwW

![](http://www.reactiongifs.com/r/whites.gif)