### PR TITLE
Add link to "Contact" page

### DIFF
--- a/app/views/pages/outlets.html.erb
+++ b/app/views/pages/outlets.html.erb
@@ -35,10 +35,8 @@
       Buy Direct
     </h2>
 
-    <p>
-      You are welcome to order products directly from us.  Please email for
-      further details.
-    </p>
+    <p>You are welcome to order products directly from us.  Please
+    <%= link_to("contact us", contact_path) %> for further details.</p>
   </div>
 </div>
 


### PR DESCRIPTION
Previously, the "Outlets" page mentioned that customers could contact us, but there was no link to the "Contact" page, which made it difficult for customers to contact us when we should be making it easier for them.  Added a link to the "Contact" page.

https://trello.com/c/xAUCvtML

![](http://www.reactiongifs.com/r/f.gif)