### PR TITLE
Add Denise as an email recipient

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -2,9 +2,9 @@ class Mailer < ActionMailer::Base
   def order_received(order)
     @order = order
     mail(
-      from: 'Radfords <denise@radfordsofsomerford.co.uk>',
+      from: "Radfords <#{denise}>",
       subject: t(".subject", id: @order.id),
-      to: @order.email
+      to: [@order.email, denise]
     )
   end
 
@@ -15,5 +15,11 @@ class Mailer < ActionMailer::Base
       subject: t(".subject", id: @order.id),
       to: @order.email
     )
+  end
+
+  private
+
+  def denise
+    "denise@radfordsofsomerford.co.uk"
   end
 end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -17,16 +17,17 @@ describe Mailer do
       )
     end
 
+    let(:denise) { "denise@radfordsofsomerford.co.uk" }
     let(:email) { 'alphonso.quigley@example.com' }
     let(:id) { 5 }
     let(:title) { "Order confirmation for order #{id}" }
 
     it 'sends a mail from Denise' do
-      expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])
+      expect(subject.from).to eql([denise])
     end
 
-    it 'sends a mail to the order email' do
-      expect(subject.to).to eql([email])
+    it "sends a mail to the order email and Denise" do
+      expect(subject.to).to eql([email, denise])
     end
 
     it 'sends a mail with the correct subject' do


### PR DESCRIPTION
Previously, the order confirmation email was only received by customers, which meant that Denise had to actively check the order list for new orders. Added Denise to the list of recipients for the order confirmation email.