### PR TITLE
Remove checkout restrictions

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,8 +1,6 @@
 module PagesHelper
   def product_button(product)
-    if signed_in?
-      render(partial: "shared/product_button", locals: { product: product })
-    end
+    render(partial: "shared/product_button", locals: { product: product })
   end
 
   def render_basket(basket)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,9 +19,7 @@
         <%= link_to "Contact us", contact_path %>
       </li>
 
-      <% if signed_in? %>
-        <li><%= link_to(t(".basket", item_count: @basket.item_count), basket_path) %></li>
-      <% end %>
+      <li><%= link_to(t(".basket", item_count: @basket.item_count), basket_path) %></li>
     </ul>
   </div>
 </div>

--- a/features/baskets.feature
+++ b/features/baskets.feature
@@ -7,16 +7,14 @@ Feature: Baskets
     And I see a "Your basket is empty" message
 
   Scenario:
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     When I empty my basket
     Then I see the "Your Basket" page
     And I see a "Your basket is currently empty" notice
 
   Scenario: Add a product to my basket
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     And I am on the "Shop" page
     When I add the product to my basket
@@ -24,8 +22,7 @@ Feature: Baskets
     And I see the product in my basket twice
 
   Scenario: Remove all items from the basket
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     And I am viewing my basket
     When I remove the product from my basket
@@ -33,8 +30,7 @@ Feature: Baskets
     And I see a "Your basket is empty" message
 
   Scenario: Link to product page
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     And I am viewing my basket
     When I click on the product

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -7,8 +7,7 @@ Feature: Orders
     And I see a "Your basket is empty" notice
 
   Scenario:
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     And I have checked out my basket
     When I create the order
@@ -16,8 +15,7 @@ Feature: Orders
     And I see a "Thank you" message
 
   Scenario:
-    Given I am signed in
-    And a product exists
+    Given a product exists
     And I have the product in my basket
     And I have checked out my basket
     When I create the order incorrectly

--- a/spec/features/layouts/header_spec.rb
+++ b/spec/features/layouts/header_spec.rb
@@ -2,20 +2,12 @@ require "spec_helper"
 
 describe "application header" do
   let(:home_page) { HomePage.new }
-  let(:signin_page) { SigninPage.new(user.email, user.password) }
   let(:user) { FactoryGirl.create(:user) }
-
-  before { sign_in }
 
   it "navigates to 'Your Basket'" do
     home_page.visit
     home_page.go_to_basket
 
     expect(page).to have_title "Your Basket"
-  end
-
-  def sign_in
-    signin_page.visit
-    signin_page.sign_in
   end
 end

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -4,7 +4,6 @@ module Features
   describe "edit line item" do
     it "increases the item's quantity" do
       create :product
-      sign_in
       add_products_to_basket
 
       basket_page.visit
@@ -15,7 +14,6 @@ module Features
 
     it "decreases the item's quantity" do
       create :product
-      sign_in
       add_products_to_basket
 
       basket_page.visit
@@ -27,7 +25,6 @@ module Features
 
     it "only allows positive quantities" do
       create :product
-      sign_in
       add_products_to_basket
 
       basket_page.visit
@@ -38,7 +35,6 @@ module Features
 
     it "keeps the items in the correct order" do
       create_products
-      sign_in
       add_products_to_basket
 
       basket_page.visit
@@ -62,12 +58,6 @@ module Features
     def create_products
       create(:product, title: "Plum Jam")
       create(:product, title: "Rhubarb and Ginger Jam")
-    end
-
-    def sign_in
-      page = NewSessionPage.new
-      page.visit
-      page.sign_in
     end
   end
 end

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 module Features
   describe "create order" do
     it "show order summary" do
-      sign_in
       create_product
       create_basket
 
@@ -21,12 +20,6 @@ module Features
 
     def create_product
       FactoryGirl.create(:product)
-    end
-
-    def sign_in
-      page = NewSessionPage.new
-      page.visit
-      page.sign_in
     end
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -6,26 +6,16 @@ describe PagesHelper do
 
     let(:partial) { double('partial') }
     let(:product) { double('product') }
-    let(:signed_in?) { false }
 
     before do
-      allow(helper).to receive(:signed_in?).with(no_args).and_return(signed_in?)
       allow(helper).to receive(:render).with(
         partial: "shared/product_button",
         locals: { product: product }
       ).once.and_return(partial)
     end
 
-    it 'returns nil' do
-      expect(subject).to be_nil
-    end
-
-    context 'when the user is signed in' do
-      let(:signed_in?) { true }
-
-      it 'renders the partial' do
-        expect(subject).to be(partial)
-      end
+    it "renders the partial" do
+      expect(subject).to be(partial)
     end
   end
 


### PR DESCRIPTION
Previously, you had to be signed into the application to buy products, which meant that only administrators could make a purchase. The restrictions around the purchase path have been removed.