### PR TITLE
Fix the destroy line items spec

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     basket:
       checkout: Checkout
       confirm: Are you sure?
-      destroy: "Delete"
+      destroy: "Remove"
       empty_basket: Empty basket
     destroy:
       notice: Your basket is currently empty.

--- a/config/locales/views/baskets/en.yml
+++ b/config/locales/views/baskets/en.yml
@@ -1,4 +1,0 @@
-en:
-  baskets:
-    basket:
-      destroy: Remove


### PR DESCRIPTION
Previously, there were two definitions for the locales on the basket page and they were not always being loaded in the same order, which was causing inconsistencies in the UI and for the test suite to sometimes fail. Removed the duplicate locale definition.

https://trello.com/c/8z8gPogX

![](http://www.reactiongifs.com/r/unpwr.gif)