### PR TITLE
Generate spec/support/i18n.rb file

### DIFF
--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include AbstractController::Translation
+end


### PR DESCRIPTION
* Enable using just `t` (not `I18n.t`) in specs which was introduced in 7ea5176 and removed in eaf7de1
* Add spec to ensure i18n support file is added

https://trello.com/c/2DrwV80l

![](http://www.reactiongifs.com/r/hfma.gif)