### PR TITLE
Do not ignore errors when checking for foreman

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,7 +27,7 @@ if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
 fi
 
 # Print warning if Foreman is not installed
-if ! command -v foreman &>/dev/null; then
+if ! command -v foreman > /dev/null; then
   echo "foreman is not installed."
   echo "See https://github.com/ddollar/foreman for install instructions."
 fi


### PR DESCRIPTION
The `&>` syntax is not valid sh. Instead of changing it to valid sh syntax (`2>&1 > /dev/null`), we can instead drop the `&` entirely.

If `command` prints to stderr, `foreman` may or may not be installed. In this case the user will want to know that there was an error; telling them that `foreman` is not installed masks the error, making debugging trickier.

https://trello.com/c/VxJp9gIJ

![](http://www.reactiongifs.com/r/pda.gif)