### PR TITLE
Raise unpermitted parameters in test environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,6 @@ module Radfords
     config.assets.version = '1.0'
 
     config.assets.initialize_on_precompile = false
+    config.action_controller.action_on_unpermitted_parameters = :raise
   end
 end


### PR DESCRIPTION
Unpermitted parameters were being raised in the development environment but ignored in the test environment. That can cause specs to pass even though performing the same steps in development will fail.

This change raises unpermitted parameters in all environments for parity.

https://trello.com/c/7dcqRmvY

![](http://www.reactiongifs.com/r/spnk.gif)