### PR TITLE
Remove unused flash text

### DIFF
--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -6,7 +6,7 @@
       <% alert_type = flash_message_class(key) %>
 
       <%= content_tag(:div, class: ['alert', "alert-#{alert_type}"]) do %>
-        <strong><%= t("#{alert_type}_text") %>!</strong> <%= value %>
+        <%= value %>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Previously, the flashes were being displayed along with content that was not defined in the locale, which meant that users were seeing untranslated text. The flashes have been update to no longer show the content.

https://trello.com/c/V0kQYi1u

![](http://www.reactiongifs.com/r/clws.gif)