### PR TITLE
Raise on missing translations in test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ Radfords::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
   config.assets.allow_debugging = true


### PR DESCRIPTION
Although we're generating a separate `spec/support/i18n.rb` file for i18n (4d30479c3750ad5ce708cbf03ab8a58d484f2e8a), we're once again **not** failing specs when a translation is missing.

https://trello.com/c/hrlGsFlN

![](http://www.reactiongifs.com/r/dslk.gif)