### PR TITLE
Generate rails_helper, not spec_helper

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe ApplicationController do
   describe '#authenticate' do

--- a/spec/controllers/baskets_controller_spec.rb
+++ b/spec/controllers/baskets_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe BasketsController do
   describe 'GET "show"' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe EventsController do
   let(:event_params) do

--- a/spec/controllers/fulfilments_controller_spec.rb
+++ b/spec/controllers/fulfilments_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe FulfilmentsController do
   describe 'POST "create"' do

--- a/spec/controllers/line_items_controller_spec.rb
+++ b/spec/controllers/line_items_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe LineItemsController do
   describe 'POST "create"' do

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe OrdersController do
   describe "GET 'new'" do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe PagesController do
   before (:each) do

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe ProductsController do
   let(:product_params) do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe SessionsController do
   describe 'GET "new"' do
@@ -62,13 +62,13 @@ describe SessionsController do
   end
 
   describe "DELETE 'destroy'" do
-    it "should sign a user out" do
-      test_sign_in( FactoryGirl.create(:user) )
+    before do
+      allow(controller).to receive(:find_basket)
+      allow(controller).to receive(:sign_out)
+    end
 
+    it "redirects to the home page" do
       delete :destroy
-
-      expect(controller).to_not be_signed_in
-
       expect(response).to redirect_to(root_path)
     end
 

--- a/spec/controllers/suppliers_controller_spec.rb
+++ b/spec/controllers/suppliers_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe SuppliersController do
   let(:supplier_params) do

--- a/spec/features/layouts/header_spec.rb
+++ b/spec/features/layouts/header_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe "application header" do
   let(:home_page) { HomePage.new }

--- a/spec/features/line_items/destroy_spec.rb
+++ b/spec/features/line_items/destroy_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 module Features
   describe "destroy line item" do

--- a/spec/features/line_items/edit_spec.rb
+++ b/spec/features/line_items/edit_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 module Features
   describe "edit line item" do

--- a/spec/features/line_items/new_spec.rb
+++ b/spec/features/line_items/new_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 module Features
   describe "create from product page" do

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 module Features
   describe 'fulfil order' do

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 module Features
   describe "create order" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe ApplicationHelper do
   describe '#flash_message_class' do

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe OrdersHelper do
   describe '#show_order_button' do

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe PagesHelper do
   describe '#product_button' do

--- a/spec/helpers/product_helper_spec.rb
+++ b/spec/helpers/product_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe ProductHelper do
   describe '#product_list' do

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe Mailer do
   describe '.order_received' do

--- a/spec/models/basket_decorator_spec.rb
+++ b/spec/models/basket_decorator_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe BasketDecorator do
   let(:decorator) { BasketDecorator.new(basket) }

--- a/spec/models/basket_spec.rb
+++ b/spec/models/basket_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe Basket do
   let(:basket) { Basket.new }

--- a/spec/models/charges_customers_spec.rb
+++ b/spec/models/charges_customers_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe ChargesCustomers do
   let(:charger) { ChargesCustomers.new(email, card, amount, order_id) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,7 +10,7 @@
 #  updated_at     :datetime
 #
 
-require 'spec_helper'
+require "rails_helper"
 
 describe Event do
   before (:each) do

--- a/spec/models/find_basket_spec.rb
+++ b/spec/models/find_basket_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe FindBasket do
   describe ".call" do

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe LineItem do
   let(:item) { LineItem.new }

--- a/spec/models/missing_basket_spec.rb
+++ b/spec/models/missing_basket_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe MissingBasket do
   describe "#line_items" do

--- a/spec/models/null_basket_spec.rb
+++ b/spec/models/null_basket_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe NullBasket do
   let(:basket) { NullBasket.new }

--- a/spec/models/order_builder_spec.rb
+++ b/spec/models/order_builder_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 describe OrderBuilder do
   describe ".build" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe Order do
   let(:order) do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "rails_helper"
 
 describe Product do
   let(:product) { described_class.new }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,7 +11,7 @@
 #  salt               :string(255)
 #
 
-require 'spec_helper'
+require "rails_helper"
 
 describe User do
   before(:each) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,40 @@
+ENV["RAILS_ENV"] ||= "test"
+
+require File.expand_path("../../config/environment", __FILE__)
+
+require "rspec/rails"
+require "shoulda/matchers"
+
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
+
+module Features
+  # Extend this module in spec/support/features/*.rb
+  include Formulaic::Dsl
+end
+
+RSpec.configure do |config|
+  config.include Features, type: :feature
+  config.infer_base_class_for_anonymous_controllers = false
+  config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = false
+end
+
+ActiveRecord::Migration.maintain_test_schema!
+Capybara.javascript_driver = :webkit
+
+require "webmock/rspec"
+
+# http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+
+  config.order = :random
+end
+
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,26 +1,16 @@
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../../config/environment", __FILE__)
-require 'rspec/rails'
-require 'shoulda/matchers'
+require "webmock/rspec"
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
-module Features
-  # Extend this module in spec/support/features/*.rb
-  include Formulaic::Dsl
-end
-
+# http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.mock_with :rspec
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
-  config.infer_base_class_for_anonymous_controllers = false
-  config.infer_spec_type_from_file_location!
-  config.order = "random"
-
-  def test_sign_in(user)
-    controller.sign_in(user)
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
   end
+
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+
+  config.order = :random
 end
 
-ActiveRecord::Migration.maintain_test_schema!
+WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
RSpec 3.x introduces a `spec/rails_helper.rb` file which contains all dependencies necessary to run specs that need Rails.

https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#default-helper-files

Achieves the goal of "Documenting Explicit Dependencies Through Tests":

http://robots.thoughtbot.com/document-explicit-dependencies-through-tests

* Move Rails-specific things to rails_helper.rb.
* Require spec_helper.rb from rails_helper.rb.
* Remove duplication across files.
* We do not need to require "spec_helper" manually.
  It is required for us in `.rspec`:

    --color
    --warnings
    --require spec_helper

https://trello.com/c/ruo0X8u3

![](http://www.reactiongifs.com/r/ild.gif)