### PR TITLE
Turn off RSpec verbose mode by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,12 @@ require File.expand_path('../config/application', __FILE__)
 require 'rake'
 
 Radfords::Application.load_tasks
+task(:default).clear
+task default: [:spec]
+
+if defined? RSpec
+  task(:spec).clear
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.verbose = false
+  end
+end


### PR DESCRIPTION
This prevents RSpec from printing the command that it runs when you run rake, which clutters the screen.

https://trello.com/c/JUPDs1yD

![](http://www.reactiongifs.com/r/wddd.gif)