### PR TITLE
Fix Bundler installation code

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,11 +6,7 @@
 # Exit if any subcommand fails
 set -e
 
-# Set up Ruby dependencies via Bundler
-if ! command -v bundle > /dev/null; then
-  gem install bundler --no-document
-fi
-
+bundle --version &> /dev/null || gem install bundler --no-document
 bundle install
 
 # Set up configurable environment variables


### PR DESCRIPTION
Our previous Bundler idempotency code did not work if you had a version of Bundler installed on a different Ruby version.

https://trello.com/c/DX1uwGQZ

![](http://www.reactiongifs.com/r/smdh.gif)