### PR TITLE
Upgrade newrelic gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jquery-rails'
 gem 'kaminari'
 gem 'money-rails'
 gem 'neat', '~> 1.5.1'
-gem 'newrelic_rpm', '>= 3.7.3'
+gem 'newrelic_rpm'
 gem "normalize-rails", "~> 3.0.0"
 gem 'paperclip'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       bourbon (>= 3.1)
       sass (~> 3.2.19)
     netrc (0.9.0)
-    newrelic_rpm (3.9.7.266)
+    newrelic_rpm (3.12.1.298)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
@@ -274,7 +274,7 @@ DEPENDENCIES
   launchy
   money-rails
   neat (~> 1.5.1)
-  newrelic_rpm (>= 3.7.3)
+  newrelic_rpm
   normalize-rails (~> 3.0.0)
   paperclip
   pg


### PR DESCRIPTION
* Specified version gives alert that newrelic "requires a security update for their Postgres explain plan support"
* Gem version was last set in July 2013:
* https://github.com/thoughtbot/suspenders/commit/8f133d2bd0f67097495a9c120f724754ef7b0285#diff-2b85b2e387999d51ca372ef132583e80

https://trello.com/c/aMZA9cku

![](http://www.reactiongifs.com/r/lnwh.gif)