### PR TITLE
Use Heroku-recommended timeout numbers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'newrelic_rpm'
 gem "normalize-rails", "~> 3.0.0"
 gem 'paperclip'
 gem 'pg'
+gem 'rack-timeout'
 gem 'rails', '4.1.7'
 gem 'recipient_interceptor'
 gem 'sass-rails', '~> 4.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.2.4)
     rails (4.1.7)
       actionmailer (= 4.1.7)
       actionpack (= 4.1.7)
@@ -278,6 +279,7 @@ DEPENDENCIES
   normalize-rails (~> 3.0.0)
   paperclip
   pg
+  rack-timeout
   rails (= 4.1.7)
   rails_12factor
   recipient_interceptor

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,1 @@
+Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,5 +1,5 @@
-worker_processes (ENV["WEB_CONCURRENCY"] || 3).to_i
-timeout (ENV["WEB_TIMEOUT"] || 5).to_i
+worker_processes (ENV["UNICORN_WORKERS"] || 3).to_i
+timeout (ENV["UNICORN_TIMEOUT"] || 5).to_i
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
Rename ENV variables to be very explicit. Couples their names to their libraries.

https://trello.com/c/s3R61cGX

![](http://www.reactiongifs.com/r/lnggng.gif)