### PR TITLE
Add bundler-audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 ruby '2.1.4'
 
@@ -19,12 +19,16 @@ gem "normalize-rails", "~> 3.0.0"
 gem 'paperclip'
 gem 'pg'
 gem 'rack-timeout'
-gem 'rails', '4.1.8'
+gem 'rails', '4.1.11'
 gem 'recipient_interceptor'
 gem 'sass-rails', '~> 4.0.3'
 gem 'stripe'
 gem 'uglifier'
 gem 'unicorn'
+
+group :development do
+  gem "bundler-audit"
+end
 
 group :development, :test do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.8)
-      actionpack (= 4.1.8)
-      actionview (= 4.1.8)
+    actionmailer (4.1.11)
+      actionpack (= 4.1.11)
+      actionview (= 4.1.11)
       mail (~> 2.5, >= 2.5.4)
-    actionpack (4.1.8)
-      actionview (= 4.1.8)
-      activesupport (= 4.1.8)
+    actionpack (4.1.11)
+      actionview (= 4.1.11)
+      activesupport (= 4.1.11)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.8)
-      activesupport (= 4.1.8)
+    actionview (4.1.11)
+      activesupport (= 4.1.11)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activemodel (4.1.8)
-      activesupport (= 4.1.8)
+    activemodel (4.1.11)
+      activesupport (= 4.1.11)
       builder (~> 3.1)
-    activerecord (4.1.8)
-      activemodel (= 4.1.8)
-      activesupport (= 4.1.8)
+    activerecord (4.1.11)
+      activemodel (= 4.1.11)
+      activesupport (= 4.1.11)
       arel (~> 5.0.0)
-    activesupport (4.1.8)
+    activesupport (4.1.11)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -41,6 +41,9 @@ GEM
       sass (~> 3.2)
       thor
     builder (3.2.2)
+    bundler-audit (0.4.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (4.0.5)
       columnize (= 0.9.0)
     capybara (2.4.4)
@@ -51,7 +54,7 @@ GEM
       xpath (~> 2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
-    cocaine (0.5.4)
+    cocaine (0.5.7)
       climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -77,6 +80,8 @@ GEM
       rails (>= 3, < 5)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
     dotenv-rails (1.0.2)
       dotenv (= 1.0.2)
@@ -107,6 +112,8 @@ GEM
       multi_json (~> 1.3)
     highline (1.7.2)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0.beta1)
     i18n-tasks (0.8.3)
       activesupport
@@ -116,7 +123,7 @@ GEM
       i18n
       term-ansicolor
       terminal-table
-    jquery-rails (3.1.2)
+    jquery-rails (3.1.3)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -145,12 +152,12 @@ GEM
     neat (1.5.1)
       bourbon (>= 3.1)
       sass (~> 3.2.19)
-    netrc (0.9.0)
+    netrc (0.10.3)
     newrelic_rpm (3.12.1.298)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
-    paperclip (4.2.0)
+    paperclip (4.2.2)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
@@ -160,24 +167,24 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack-timeout (0.2.4)
-    rails (4.1.8)
-      actionmailer (= 4.1.8)
-      actionpack (= 4.1.8)
-      actionview (= 4.1.8)
-      activemodel (= 4.1.8)
-      activerecord (= 4.1.8)
-      activesupport (= 4.1.8)
+    rails (4.1.11)
+      actionmailer (= 4.1.11)
+      actionpack (= 4.1.11)
+      actionview (= 4.1.11)
+      activemodel (= 4.1.11)
+      activerecord (= 4.1.11)
+      activesupport (= 4.1.11)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.8)
+      railties (= 4.1.11)
       sprockets-rails (~> 2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
     rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
-    railties (4.1.8)
-      actionpack (= 4.1.8)
-      activesupport (= 4.1.8)
+    railties (4.1.11)
+      actionpack (= 4.1.11)
+      activesupport (= 4.1.11)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
@@ -185,7 +192,8 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     request_store (1.1.0)
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec-core (3.0.4)
@@ -240,6 +248,9 @@ GEM
     uglifier (2.5.3)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -258,6 +269,7 @@ DEPENDENCIES
   airbrake
   aws-sdk
   bourbon (~> 3.2.1)
+  bundler-audit
   byebug
   capybara
   coffee-rails
@@ -280,7 +292,7 @@ DEPENDENCIES
   paperclip
   pg
   rack-timeout
-  rails (= 4.1.8)
+  rails (= 4.1.11)
   rails_12factor
   recipient_interceptor
   rspec-rails (~> 3.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,5 @@ if defined? RSpec
     t.verbose = false
   end
 end
+
+task default: "bundler:audit"

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,11 @@
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/cli"
+
+  namespace :bundler do
+    task :audit do
+      %w(update check).each do |command|
+        Bundler::Audit::CLI.start [command]
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've used this on a couple projects. Here's what it does:

* Scans your Gemfile for insecure dependencies.
* Uses publishd CVEs to find vulnerabilities.

To get set up with bundler-audit, this commit:

* Adds it to the development dependencies.
* Adds a rake task to invoke the CLI.
* Adds it to your default `rake` run.

https://trello.com/c/PltmBueK/210

https://trello.com/c/qdTR1EHU

![](http://www.reactiongifs.com/r/fgks.gif)