### PR TITLE
Change JSON time format

### DIFF
--- a/config/initializers/json_encoding.rb
+++ b/config/initializers/json_encoding.rb
@@ -1,0 +1,1 @@
+ActiveSupport::JSON::Encoding.time_precision = 0


### PR DESCRIPTION
The [Heroku API Design Guide][guide] says timestamps should be ISO8601. By default, Rails uses millisecond-level precision. This changes it to second-level precision.

[guide]: https://github.com/interagent/http-api-design#provide-standard-timestamps

* Before: `2014-10-20T20:31:29.542Z`
* After: `2014-10-20T20:31:29Z`

https://trello.com/c/pl01GCJq

![](http://www.reactiongifs.com/r/ghf1.gif)