### PR TITLE
Use bin/setup from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-before_script:
-  - cp .sample.env .env
-  - psql -c 'create database "radfords_test";' -U postgres
-  - bundle exec rake db:migrate db:test:prepare
+install:
+  - bin/setup
 branches:
   only:
     - master

--- a/bin/setup
+++ b/bin/setup
@@ -6,7 +6,7 @@
 # Exit if any subcommand fails
 set -e
 
-bundle --version &> /dev/null || gem install bundler --no-document
+gem list bundler --installed &> /dev/null || gem install bundler --no-document
 bundle install
 
 # Set up configurable environment variables
@@ -21,15 +21,13 @@ bundle exec rake db:setup dev:prime
 mkdir -p .git/safe
 
 # Pick a port for Foreman
-if ! grep -qs 'port' .foreman; then
+if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
   printf 'port: 9000\n' >> .foreman
 fi
 
-# Error out if Foreman is not installed
 if ! command -v foreman > /dev/null; then
   printf 'Foreman is not installed.\n'
   printf 'See https://github.com/ddollar/foreman for install instructions.\n'
-  exit 1
 fi
 
 # Only if this isn't CI


### PR DESCRIPTION
In order to test the executable documentation provided by bin/setup, we should use `bin/setup` from CI.

I transitioned checks for gem presence to use `gem list --installed` and to omit the `--no-document` flag. This flag should be decided by the user's `.gemrc`.

Stop redirecting STDERR.

Expand grep flags and add --fixed-strings

The expanded flags tell me what this is doing. `--fixed-strings` gives a tiny speed boost because we're not using regex here.

https://trello.com/c/vsM3qmv3

![](http://www.reactiongifs.com/r/hmies1.gif)