### PR TITLE
Add `bin/deploy` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ programming in style.
 * [Protocol](http://github.com/thoughtbot/guides/blob/master/protocol)
 * [Best Practices](http://github.com/thoughtbot/guides/blob/master/best-practices)
 * [Style](http://github.com/thoughtbot/guides/blob/master/style)
+
+Deploying
+---------
+
+If you have previously run the `.bin/setup` script, you can deploy to staging
+and production with:
+
+    $ ./bin/deploy staging
+    $ ./bin/deploy production

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run this script to deploy the app to Heroku.
+
+set -e
+
+branch="$(git symbolic-ref HEAD --short)"
+target="${1:-staging}"
+
+git push "$target" "$branch:master"
+heroku run rake db:migrate --remote "$target"
+heroku restart --remote "$target"


### PR DESCRIPTION
* Help avoid forgetting to run `rake db:migrate`.
* Help avoid forgetting to run `restart` after migrate.
* Allow each app to edit these deploy instructions to fit their environments' needs (such as `run rake purge` to clear a cache) but maintain the same `./bin/deploy` interface and convention that is consistent with our many Middleman and Rails apps.
* Use the shebang line for POSIX sh.
* Default the argument to 'staging'

https://trello.com/c/MrLWjKGE

![](http://www.reactiongifs.com/r/yfu.gif)