### PR TITLE
Updated _flashes.html.erb with proper id

### DIFF
--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,13 +1,7 @@
 <% if flash.any? %>
-  <% flash.each do |key, value| %>
-    <% if flash[:partial] %>
-      <%= render(partial: "/shared/flashes/#{flash[:partial]}") %>
-    <% else %>
-      <% alert_type = flash_message_class(key) %>
-
-      <%= content_tag(:div, class: ['alert', "alert-#{alert_type}"]) do %>
-        <%= value %>
-      <% end %>
-    <% end %>
-  <% end %>
+  <div id="flash">
+    <% flash.each do |key, value| -%>
+      <div class="flash-<%= key %>"><%= value %></div>
+    <% end -%>
+  </div>
 <% end %>


### PR DESCRIPTION
In Bitters' generated `flash.scss`, the selectors use "-" instead of "_".

http://refills.bourbon.io/components/#flashes

https://trello.com/c/qZdZawD4

![](http://www.reactiongifs.com/r/dmbfndd.gif)