### PR TITLE
Do not require bundler-audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,11 +28,11 @@ gem 'uglifier', '2.7.2'
 gem 'unicorn'
 
 group :development do
-  gem "bundler-audit"
   gem 'web-console'
 end
 
 group :development, :test do
+  gem "bundler-audit", require: false
   gem "byebug"
   gem 'dotenv-rails'
   gem 'factory_girl_rails'


### PR DESCRIPTION
Previously, bundler-audit was only bundled in the Development environment, which meant that the gem was not available in the Test environment. Moved the gem to be included in both environments and stopped it from being required by default as it is not required by Rails.

https://trello.com/c/PliBNeDC

![](http://www.reactiongifs.com/r/bcs1.gif)