### PR TITLE
Use only rails_stdout_logging, not rails_12factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,56 +1,65 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby '2.2.0'
+ruby "2.2.0"
 
-gem 'airbrake'
-gem 'aws-sdk'
-gem 'bourbon', '~> 3.2.1'
-gem 'coffee-rails', '~> 4.1.0'
-gem 'geocoder'
-gem 'draper'
-gem 'friendly_id'
+gem "airbrake"
+gem "aws-sdk"
+gem "bourbon", "~> 3.2.1"
+gem "coffee-rails", "~> 4.1.0"
+gem "delayed_job_active_record"
+gem "draper"
+gem "email_validator"
+gem "flutie"
+gem "friendly_id"
+gem "geocoder"
+gem "high_voltage"
 gem "i18n-tasks"
-gem 'jquery-rails'
-gem 'kaminari'
-gem 'money-rails'
-gem 'neat', '~> 1.5.1'
-gem 'newrelic_rpm'
+gem "jquery-rails"
+gem "kaminari"
+gem "money-rails"
+gem "neat", "~> 1.5.1"
+gem "newrelic_rpm"
 gem "normalize-rails", "~> 3.0.0"
-gem 'paperclip'
-gem 'pg'
-gem 'rack-timeout'
-gem 'rails', '4.2.2'
-gem 'recipient_interceptor'
-gem 'sass-rails', '~> 5.0'
-gem 'simple_form'
-gem 'stripe'
-gem 'uglifier', '2.7.2'
-gem 'unicorn'
+gem "paperclip"
+gem "pg"
+gem "rack-timeout"
+gem "rails", "4.2.2"
+gem "recipient_interceptor"
+gem "sass-rails", "~> 5.0"
+gem "simple_form"
+gem "stripe"
+gem "title"
+gem "uglifier"
+gem "unicorn"
 
 group :development do
-  gem 'web-console'
+  gem "spring"
+  gem "spring-commands-rspec"
+  gem "web-console"
 end
 
 group :development, :test do
+  gem "awesome_print"
   gem "bundler-audit", require: false
   gem "byebug"
-  gem 'dotenv-rails'
-  gem 'factory_girl_rails'
-  gem 'rspec-rails'
+  gem "dotenv-rails"
+  gem "factory_girl_rails"
+  gem "pry-rails"
+  gem "rspec-rails", "~> 3.0.0"
 end
 
 group :test do
-  gem 'capybara'
-  gem 'cucumber-rails', require: false
-  gem 'database_cleaner'
-  gem 'formulaic'
-  gem 'launchy'
-  gem 'shoulda-matchers', require: false
-  gem 'timecop'
-  gem 'vcr'
-  gem 'webmock'
+  gem "capybara-webkit", ">= 1.2.0"
+  gem "cucumber-rails", require: false
+  gem "database_cleaner"
+  gem "formulaic"
+  gem "launchy"
+  gem "shoulda-matchers", require: false
+  gem "timecop"
+  gem "vcr"
+  gem "webmock"
 end
 
 group :staging, :production do
-  gem 'rails_12factor'
+  gem "rails_stdout_logging"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       builder
       multi_json
     arel (6.0.3)
+    awesome_print (1.6.1)
     aws-sdk (1.59.0)
       aws-sdk-v1 (= 1.59.0)
     aws-sdk-v1 (1.59.0)
@@ -63,10 +64,14 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.7.0)
+      capybara (>= 2.3.0, < 2.6.0)
+      json
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.7)
       climate_control (>= 0.0.3, < 1.0)
+    coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -91,6 +96,11 @@ GEM
       rails (>= 3, < 5)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     diff-lcs (1.2.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
@@ -106,6 +116,8 @@ GEM
       json
       thread
       thread_safe
+    email_validator (1.6.0)
+      activemodel
     erubis (2.7.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -113,6 +125,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    flutie (2.0.0)
     formulaic (0.1.2)
       activesupport
       capybara
@@ -124,6 +137,7 @@ GEM
       multi_json (~> 1.3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    high_voltage (2.4.0)
     highline (1.7.2)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -150,6 +164,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.8.0)
@@ -178,6 +193,12 @@ GEM
       cocaine (~> 0.5.3)
       mime-types
     pg (0.17.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -201,10 +222,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.2)
     rails_stdout_logging (0.0.3)
     railties (4.2.2)
       actionpack (= 4.2.2)
@@ -220,23 +237,22 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec-core (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-rails (3.3.3)
-      actionpack (>= 3.0, < 4.3)
-      activesupport (>= 3.0, < 4.3)
-      railties (>= 3.0, < 4.3)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.4)
+      rspec-support (~> 3.0.0)
+    rspec-rails (3.0.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.4)
     safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (5.0.3)
@@ -250,6 +266,10 @@ GEM
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
+    slop (3.6.0)
+    spring (1.3.6)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.3.3)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -269,6 +289,9 @@ GEM
     tilt (1.4.1)
     timecop (0.7.1)
     tins (1.5.4)
+    title (0.0.5)
+      i18n
+      rails (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -298,20 +321,25 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake
+  awesome_print
   aws-sdk
   bourbon (~> 3.2.1)
   bundler-audit
   byebug
-  capybara
+  capybara-webkit (>= 1.2.0)
   coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner
+  delayed_job_active_record
   dotenv-rails
   draper
+  email_validator
   factory_girl_rails
+  flutie
   formulaic
   friendly_id
   geocoder
+  high_voltage
   i18n-tasks
   jquery-rails
   kaminari
@@ -322,17 +350,21 @@ DEPENDENCIES
   normalize-rails (~> 3.0.0)
   paperclip
   pg
+  pry-rails
   rack-timeout
   rails (= 4.2.2)
-  rails_12factor
+  rails_stdout_logging
   recipient_interceptor
-  rspec-rails
+  rspec-rails (~> 3.0.0)
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form
+  spring
+  spring-commands-rspec
   stripe
   timecop
-  uglifier (= 2.7.2)
+  title
+  uglifier
   unicorn
   vcr
   web-console

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,10 +7,6 @@ module ApplicationHelper
     humanized_money_with_symbol(price, no_cents_if_whole: false)
   end
 
-  def title
-    "#{content_for(:title).presence || @title} | Radfords of Somerford"
-  end
-
   def nav_class(controller_name)
     if controller_name == controller.controller_name
       "active"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="initial-scale=1" />
-  <title><%= title %></title>
+  <title><%= title %> | <%= t("titles.application") %></title>
   <%= csrf_meta_tag %>
   <meta name="description" content="Buy homemade jams and preserves online with Radfords of Somerford. Fantastic homemade jams and preserves made with local produce in the heart of Cheshire." />
   <%= render 'layouts/stylesheets' %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,66 +1,94 @@
-require Rails.root.join('config/smtp')
-Radfords::Application.configure do
-  # Settings specified here will take precedence over those in config/application.rb
+require Rails.root.join("config/smtp")
+Rails.application.configure do
+  # Settings specified here will take precedence over those in
+  # config/application.rb.
 
-  # The production environment is meant for finished, "live" apps.
-  # Code is not reloaded between requests
+  # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # Full error reports are disabled and caching is turned on
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
   config.static_cache_control = "public, max-age=#{1.year.to_i}"
+  # Enable deflate / gzip compression of controller-generated responses
+  config.middleware.use Rack::Deflater
 
-  # Compress JavaScripts and CSS
-  config.assets.compress = true
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
 
-  # Don't fallback to assets pipeline if a precompiled asset is missed
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Generate digests for assets URLs
+  # Asset digests allow you to set far-future HTTP expiration dates on all
+  # assets, yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # Specifies the header that your server uses for sending files
-  config.action_dispatch.x_sendfile_header = "X-Sendfile"
+  # `config.assets.precompile` and `config.assets.version` have moved to
+  # config/initializers/assets.rb
 
-  # For nginx:
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # If you have no front-end server that supports something like X-Sendfile,
-  # just comment this out and Rails will serve the files
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use
+  # secure cookies.
+  # config.force_ssl = true
 
-  config.force_ssl = true
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
 
-  # See everything in the log (default is :info)
-  # config.log_level = :debug
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a different logger for distributed setups
-  # config.logger = SyslogLogger.new
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production
+  # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Disable Rails's static asset server
-  # In production, Apache or nginx will already do this
-
-  # Enable serving of images, stylesheets, and javascripts from an asset server
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV.fetch("ASSET_HOST")
 
-  # Disable delivery errors, bad email addresses will be ignored
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to
+  # raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = SMTP_SETTINGS
 
 
-  # Enable threaded mode
-  # config.threadsafe!
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found)
+  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners
+  # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-  config.eager_load = true
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default_url_options = {
+    host: "radfordsofsomerford.co.uk"
+  }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,4 +83,6 @@ en:
       default: '%a, %b %-d, %Y at %r'
 
   titles:
-    application: "Radfords"
+    application: "Radfords of Somerford"
+    baskets:
+      show: "Your Basket"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,26 +43,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#title" do
-    it "returns the content for the title" do
-      allow(helper).to receive(:content_for).and_return("Foo")
-
-      title = helper.title
-
-      expect(title).to eql "Foo | Radfords of Somerford"
-    end
-
-    context "when there is no content for the title" do
-      it "returns the stored title" do
-        helper.instance_variable_set(:@title, "Bar")
-
-        title = helper.title
-
-        expect(title).to eql "Bar | Radfords of Somerford"
-      end
-    end
-  end
-
   describe "#navbar" do
     it "renders the navbar partial" do
       allow(helper).to receive(:signed_in?).and_return(true)


### PR DESCRIPTION
Previously, `rails_12factor` was being used to include the `rails_serve_static_assets` gem, which was only helpful if the site was deployed to Heroku. Included the `rails_stdout_logging` gem instead to use the community convention of relying on the `ENV["RAILS_SERVE_STATIC_FILES"]` variable.

https://trello.com/c/DG72BX8i

![](http://www.reactiongifs.com/r/wtfs.gif)