### PR TITLE
Improve SMTP_DOMAIN comment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
-    database_cleaner (1.3.0)
+    database_cleaner (1.5.0)
     debug_inspector (0.0.2)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
@@ -150,8 +150,9 @@ GEM
       i18n
       term-ansicolor
       terminal-table
-    jquery-rails (3.1.3)
-      railties (>= 3.0, < 5.0)
+    jquery-rails (4.0.5)
+      rails-dom-testing (~> 1.0)
+      railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     kaminari (0.16.1)
@@ -202,7 +203,7 @@ GEM
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rack-timeout (0.2.4)
+    rack-timeout (0.3.1)
     rails (4.2.2)
       actionmailer (= 4.2.2)
       actionpack (= 4.2.2)
@@ -271,7 +272,7 @@ GEM
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.3.3)
+    sprockets (3.3.4)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
       actionpack (>= 3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,14 +1,16 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
+// This is a manifest file that'll be compiled into application.js, which will
+// include all the files listed below.
 //
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts,
+// vendor/assets/javascripts, or any plugin's vendor/assets/javascripts
+// directory can be referenced here using a relative path.
 //
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// the compiled file.
+// It's not advisable to add code directly here, but if you do, it'll appear at
+// the bottom of the compiled file.
 //
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
+// Read Sprockets README
+// (https://github.com/rails/sprockets#sprockets-directives) for details about
+// supported directives.
 //
 //= require jquery
 //= require jquery_ujs

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,33 +1,39 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "sprockets/railtie"
+# require "rails/test_unit/railtie"
 
-if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
-  # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
-end
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
 
 module Radfords
   class Application < Rails::Application
-    ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
-      include ActionView::Helpers::OutputSafetyHelper
-      raw %(<span class="control-group error">#{html_tag}</span>)
+    config.i18n.enforce_available_locales = true
+    config.active_record.default_timezone = :utc
+
+    config.generators do |generate|
+      generate.helper false
+      generate.javascript_engine false
+      generate.request_specs false
+      generate.routing_specs false
+      generate.stylesheets false
+      generate.test_framework :rspec
+      generate.view_specs false
     end
+
+    config.action_controller.action_on_unpermitted_parameters = :raise
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
-
-    # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
-
-    # Only load the plugins named here, in the order given (default is alphabetical).
-    # :all can be used as a placeholder for all plugins not explicitly named.
-    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
-
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
@@ -36,28 +42,6 @@ module Radfords
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    config.i18n.load_path += Dir[
-      Rails.root.join("config", "locales", "**", "*.{rb,yml}")
-    ]
-    config.i18n.enforce_available_locales = true
-
-    # JavaScript files you want as :defaults (application.js is always included).
-    # config.action_view.javascript_expansions[:defaults] = %w(jquery rails)
-
-    # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
-
-    # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
-
-    # Enable the asset pipeline
-    config.assets.enabled = true
-
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
-
-    config.assets.initialize_on_precompile = false
-    config.action_controller.action_on_unpermitted_parameters = :raise
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/smtp.rb
+++ b/config/smtp.rb
@@ -1,9 +1,9 @@
 SMTP_SETTINGS = {
-  address: ENV.fetch('SMTP_ADDRESS'),
+  address: ENV.fetch("SMTP_ADDRESS"), # example: "smtp.sendgrid.net"
   authentication: :plain,
-  domain: ENV.fetch('SMTP_DOMAIN'),
+  domain: ENV.fetch("SMTP_DOMAIN"), # example: "heroku.com"
   enable_starttls_auto: true,
-  password: ENV.fetch('SMTP_PASSWORD'),
-  port: 587,
-  user_name: ENV.fetch('SMTP_USERNAME')
+  password: ENV.fetch("SMTP_PASSWORD"),
+  port: "587",
+  user_name: ENV.fetch("SMTP_USERNAME")
 }


### PR DESCRIPTION
Previously, a generic domain was given for the SMTP domain, which isn't necessarily correct according to Mandrill and SendGrid documentation.  Updated the comment to be `heroku.com` instead.

* Upgraded jquery-rails
* Brought `Application` up-to-date
* Made SMTP config Hound-compliant
* Upgraded database_cleaner, rack-timeout, and sprockets

https://trello.com/c/QjxHpHI4

![](http://www.reactiongifs.com/r/muahh.gif)