### PR TITLE
Turn off Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ cache:
 language:
   - ruby
 notifications:
-  email:
-    - false
+  email: false
   slack:
     secure: GQ3iBioeING+mB1H2NiWURymJmeXk+1Y6A0k2ZcCBsAYnBx15OPuu6svXtSHMo0cHX2dN9PbaVUtD0WiAf/JXGZ1rsiaNecsio/ZBWWQ+KEIlEPe485stHv5JoUfGyBvsUWGYBnCqEhW0KFahL8Ny3WUIIkqrg+X8HKozYrpITU=
 rvm:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     high_voltage (2.4.0)
-    highline (1.7.2)
+    highline (1.7.5)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)


### PR DESCRIPTION
Previously, the email flag in the Travis configuration was set to an array, which was not actually turning the emails off. Updated the configuration to actually return negatively.

https://trello.com/c/fKEyMHBT

![](http://www.reactiongifs.com/r/acb.gif)