### PR TITLE
Don't set default_url_options to a string

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,5 +88,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'ENV.fetch("HOST")' }
+  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -7,5 +7,5 @@ Mail.register_interceptor(
 Rails.application.configure do
   # ...
 
-  config.action_mailer.default_url_options = { host: 'ENV.fetch("HOST")' }
+  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,43 +1,45 @@
-Radfords::Application.configure do
-  # Settings specified here will take precedence over those in config/application.rb
+Rails.application.configure do
+  # Settings specified here will take precedence over those in
+  # config/application.rb.
 
   # The test environment is used exclusively to run your application's
-  # test suite.  You never need to work with it otherwise.  Remember that
+  # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs.  Don't rely on the data there!
+  # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  # Configure static asset server for tests with Cache-Control for performance
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
+  # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Show full error reports and disable caching
+  # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates
+  # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Use SQL instead of Active Record's schema dumper when creating the test database.
-  # This is necessary if your schema can't be completely dumped by the schema dumper,
-  # like if you have constraints or database-specific column types
-  # config.active_record.schema_format = :sql
+  # Randomize the order test cases are executed.
+  config.active_support.test_order = :random
 
-  # Print deprecation notices to the stderr
+  # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
-  # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
-  config.assets.allow_debugging = true
-  config.eager_load = false
+  config.action_mailer.default_url_options = { host: "www.example.com" }
 end


### PR DESCRIPTION
Previously, the `default_url_options` were being set to `'ENV.fetch("HOST")'` instead of the actual environment variable, which was causing emails to render incorrectly. Updated the environments to actually use the variable.

* Brought the test environment configuration up-to-date

https://trello.com/c/0Jh2HwU9

![](http://www.reactiongifs.com/r/trmp1.gif)