### PR TITLE
Faster, more correct gem install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -6,8 +6,9 @@
 # Exit if any subcommand fails
 set -e
 
-gem list bundler --installed &> /dev/null || gem install bundler --no-document
-bundle install
+# Set up Ruby dependencies via Bundler
+gem install bundler --conservative
+bundle check || bundle install
 
 # Set up configurable environment variables
 if [ ! -f .env ]; then


### PR DESCRIPTION
Previously, we were always installing the gems even if they were already installed, which was slowing down the setting up of the application.  Updated the setup script to only install gems if they aren't already installed.

https://trello.com/c/JsBG6yFr

![](http://www.reactiongifs.com/r/apwu.gif)