### PR TITLE
Remove default timezone; it's the default in Rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     high_voltage (2.4.0)
-    highline (1.7.5)
+    highline (1.7.7)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,6 @@ Bundler.require(*Rails.groups)
 module Radfords
   class Application < Rails::Application
     config.i18n.enforce_available_locales = true
-    config.active_record.default_timezone = :utc
 
     config.generators do |generate|
       generate.helper false


### PR DESCRIPTION
Previously, we were explicitly setting the timezone to `:utc`, which is now the default in Rails. Removed the value from the application configuration.

* Updated highline

https://trello.com/c/PD5Vwxi7

![](http://www.reactiongifs.com/r/romg.gif)