### PR TITLE
Update Bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.2.0"
 
 gem "airbrake"
 gem "aws-sdk"
-gem "bourbon", "~> 4.1.0"
+gem "bourbon", "~> 4.2.0"
 gem "coffee-rails", "~> 4.1.0"
 gem "delayed_job_active_record"
 gem "draper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,9 @@ GEM
       nokogiri (>= 1.4.4)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bourbon (4.1.1)
-      sass (~> 3.3)
-      thor
+    bourbon (4.2.5)
+      sass (~> 3.4)
+      thor (~> 0.19)
     builder (3.2.2)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
@@ -325,7 +325,7 @@ DEPENDENCIES
   airbrake
   awesome_print
   aws-sdk
-  bourbon (~> 4.1.0)
+  bourbon (~> 4.2.0)
   bundler-audit
   byebug
   capybara-webkit (>= 1.2.0)


### PR DESCRIPTION
Previously, the site was using v4.1.0 of Bourbon, which was not the latest version. Updated the gem to v4.2.0

https://trello.com/c/MGDZzFOc

![](http://www.reactiongifs.com/r/nmn.gif)