### PR TITLE
Configure Active Job queue adapter for test env

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,7 @@ module Radfords
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: "www.example.com" }
+
+  config.active_job.queue_adapter = :inline
 end


### PR DESCRIPTION
Previously, we had to manually set up the `ActiveJob` adapter, which is no longer necessary. Updated the application configuration using the built-in Rails functionality and removed the manual test configuration.

https://trello.com/c/0s5VvtIR

![](http://www.reactiongifs.com/r/fngry.gif)