### PR TITLE
Enable verify_partial_doubles

### DIFF
--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -58,7 +58,6 @@ describe EventsController do
     it "redirects to the event's page" do
       event = Event.new
       allow(event).to receive(:save!).and_return(true)
-      allow(event).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Event).to receive(:new).and_return(event)
 
@@ -70,7 +69,6 @@ describe EventsController do
     it "sets the notice flash" do
       event = Event.new
       allow(event).to receive(:save!).and_return(true)
-      allow(event).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Event).to receive(:new).and_return(event)
 
@@ -142,7 +140,6 @@ describe EventsController do
     it "redirects to the event's page" do
       event = Event.new
       allow(event).to receive(:update_attributes!).and_return(true)
-      allow(event).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Event).to receive(:find).and_return(event)
 

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -199,7 +199,6 @@ describe ProductsController do
     it "finds the product" do
       product = Product.new
       allow(product).to receive(:save!).and_return(true)
-      allow(product).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Product).to receive(:new).and_return(product)
 
@@ -211,7 +210,6 @@ describe ProductsController do
     it "sets the notice flash" do
       product = Product.new
       allow(product).to receive(:save!).and_return(true)
-      allow(product).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Product).to receive(:new).and_return(product)
 
@@ -223,7 +221,6 @@ describe ProductsController do
     it "redirects to the product's page" do
       product = Product.new
       allow(product).to receive(:save!).and_return(true)
-      allow(product).to receive(:url_for).and_return("")
       allow(controller).to receive(:authenticate)
       allow(Product).to receive(:new).and_return(product)
 

--- a/spec/features/events/new_spec.rb
+++ b/spec/features/events/new_spec.rb
@@ -15,7 +15,7 @@ module Features
     let(:location) { "Sandbach" }
     let(:password) { user.password }
     let(:signin_page) { SigninPage.new(email, password) }
-    let(:takes_place_on) { "12 October 2015" }
+    let(:takes_place_on) { Date.tomorrow.strftime("%e %B %Y") }
     let(:user) { FactoryGirl.create(:user) }
 
     it "successfully creates an event" do

--- a/spec/models/basket_spec.rb
+++ b/spec/models/basket_spec.rb
@@ -6,16 +6,20 @@ describe Basket do
   describe '#add_product' do
     subject { basket.add_product(product_id) }
 
+    let(:items) do
+      double(
+        "ActiveRecord::Relation",
+        build: new_item,
+        find_by_product_id: found_item,
+      )
+    end
+
     let(:found_item) { double(LineItem, :quantity => 1, :quantity= => nil) }
     let(:new_item) { double(LineItem) }
     let(:product_id) { '1' }
 
     before do
-      allow(basket).to receive(:line_items) { LineItem }
-      allow(LineItem).to receive(:build).with(product_id: product_id).
-        and_return(new_item)
-      allow(LineItem).to receive(:find_by_product_id).with(product_id).
-        and_return(found_item)
+      allow(basket).to receive(:line_items).and_return(items)
     end
 
     it 'returns the found item' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
+    mocks.verify_partial_doubles = true
   end
 
   config.order = :random


### PR DESCRIPTION
Previously, a method didn't have to exist to be defined in a `double`, which was causing the tests to incorrectly document the code base.  Updated the spec helper to verify that a method actually exists on a mocked object.

https://trello.com/c/fSDBk8s3

![](http://www.reactiongifs.com/r/smhp.gif)