### PR TITLE
Add SimpleCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "shoulda-matchers", require: false
+  gem "simplecov", require: false
   gem "timecop"
   gem "vcr"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,11 +36,12 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
-    airbrake (4.3.2)
+    addressable (2.3.8)
+    airbrake (4.3.3)
       builder
       multi_json
     arel (6.0.3)
+    ast (2.1.0)
     awesome_print (1.6.1)
     aws-sdk (1.59.0)
       aws-sdk-v1 (= 1.59.0)
@@ -56,8 +57,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (4.0.5)
-      columnize (= 0.9.0)
+    byebug (7.0.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -79,7 +79,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
-    columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     cucumber (1.3.17)
@@ -102,6 +101,7 @@ GEM
       activerecord (>= 3.0, < 5)
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (1.0.2)
@@ -143,14 +143,16 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    i18n-tasks (0.8.3)
-      activesupport
+    i18n-tasks (0.9.1)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
       easy_translate (>= 0.5.0)
       erubis
-      highline
+      highline (>= 1.7.3)
       i18n
-      term-ansicolor
-      terminal-table
+      parser (>= 2.2.3.0)
+      term-ansicolor (>= 1.3.2)
+      terminal-table (>= 1.5.1)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -169,7 +171,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.6.2)
     mini_portile (0.6.2)
-    minitest (5.8.1)
+    minitest (5.8.2)
     monetize (1.1.0)
       money (~> 6.5.0)
     money (6.5.1)
@@ -185,7 +187,7 @@ GEM
       bourbon (>= 4.0)
       sass (>= 3.3)
     netrc (0.10.3)
-    newrelic_rpm (3.13.2.302)
+    newrelic_rpm (3.14.0.305)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     normalize-rails (3.0.3)
@@ -194,6 +196,8 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
       mime-types
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pg (0.18.3)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -230,7 +234,7 @@ GEM
       activesupport (= 4.2.2)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.13.0)
+    raindrops (0.15.0)
     rake (10.4.2)
     recipient_interceptor (0.1.2)
       mail
@@ -264,11 +268,16 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    shoulda-matchers (3.0.0)
+    shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     spring (1.4.0)
     spring-commands-rspec (1.0.4)
@@ -285,13 +294,13 @@ GEM
       rest-client (~> 1.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    terminal-table (1.4.5)
+    terminal-table (1.5.2)
     thor (0.19.1)
-    thread (0.2.0)
+    thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.1)
     timecop (0.7.1)
-    tins (1.5.4)
+    tins (1.6.0)
     title (0.0.5)
       i18n
       rails (>= 3.1)
@@ -303,7 +312,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    unicorn (4.8.3)
+    unicorn (5.0.0)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
@@ -313,7 +322,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    webmock (1.22.1)
+    webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -364,6 +373,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form
+  simplecov
   spring
   spring-commands-rspec
   stripe

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV.fetch("COVERAGE", false)
+  require "simplecov"
+  SimpleCov.start "rails"
+end
+
 require "webmock/rspec"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Previously, SimpleCov had been removed due to an issue with the API returning successfully when it shouldn't, which meant that we had no metrics for test coverage. Re-installed the gem now that the bug is fixed.

https://trello.com/c/ICkzf05L

![](http://www.reactiongifs.com/r/tpwa.gif)