### PR TITLE
Only show user-facing flashes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.0.0)
+    byebug (8.0.1)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)

--- a/app/helpers/flashes_helper.rb
+++ b/app/helpers/flashes_helper.rb
@@ -1,0 +1,5 @@
+module FlashesHelper
+  def user_facing_flashes
+    flash.to_hash.slice("alert", "error", "notice", "success")
+  end
+end

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,6 +1,6 @@
 <% if flash.any? %>
   <div id="flash">
-    <% flash.each do |key, value| -%>
+    <% user_facing_flashes.each do |key, value| -%>
       <div class="flash-<%= key %>"><%= value %></div>
     <% end -%>
   </div>


### PR DESCRIPTION
Previously, all flashes were shown to the user, which meant that some flashes used for analytics were also shown to the user. Updated the flashes partial to only show flashes that we want the user to see.

* Upgraded byebug

https://trello.com/c/IGeIwBrD

![](http://www.reactiongifs.com/r/jlpm.gif)