### PR TITLE
Add autoprefixer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.2.1"
 
 gem "airbrake"
+gem "autoprefixer-rails"
 gem "aws-sdk"
 gem "bourbon", "~> 4.2.0"
 gem "coffee-rails", "~> 4.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       multi_json
     arel (6.0.3)
     ast (2.1.0)
+    autoprefixer-rails (6.1.0.1)
+      execjs
+      json
     awesome_print (1.6.1)
     aws-sdk (1.59.0)
       aws-sdk-v1 (= 1.59.0)
@@ -57,7 +60,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.0.1)
+    byebug (8.1.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -279,7 +282,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    spring (1.4.0)
+    spring (1.4.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (3.4.0)
@@ -300,7 +303,7 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.1)
     timecop (0.7.1)
-    tins (1.6.0)
+    tins (1.7.0)
     title (0.0.5)
       i18n
       rails (>= 3.1)
@@ -334,6 +337,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake
+  autoprefixer-rails
   awesome_print
   aws-sdk
   bourbon (~> 4.2.0)

--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,4 @@
+Last 2 versions
+Explorer >= 9
+iOS >= 7.1
+Android >= 4.4


### PR DESCRIPTION
Previously, all of the browser CSS prefixes has to be added manually, which was taking up a lot of time and effort and opened us up to potential forgetfulness. Added the autoprefixer gem to do all of this for us.

* Upgraded byebug, spring, and tins.

https://trello.com/c/G8h3G1uL

![](http://www.reactiongifs.com/r/mssd.gif)