### PR TITLE
Provide EXECJS_RUNTIME env variable

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -15,3 +15,4 @@ SMTP_PASSWORD=development_smtp_password
 SMTP_USERNAME=development_smtp_username
 STRIPE_PUBLISHABLE_KEY=development_stripe_pk
 STRIPE_SECRET_KEY=development_stripe_sk
+EXECJS_RUNTIME=Node

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.1.0)
+    byebug (8.2.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -201,7 +201,7 @@ GEM
       mime-types
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
-    pg (0.18.3)
+    pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)


### PR DESCRIPTION
Previously, no JavaScript runtime was provided, which meant that there was no control over the runtime used to compile JavaScript assets. Set the runtime to Node so that there is parity with Heroku.

* Upgraded byebug and pg.

https://trello.com/c/VjSpBN4t

![](http://www.reactiongifs.com/r/smkn.gif)