### PR TITLE
Require spec/support files in alphabetical order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.3)
+    airbrake (4.3.4)
       builder
       multi_json
     arel (6.0.3)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,11 +1,11 @@
-ENV["RAILS_ENV"] ||= "test"
+ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"
 require "shoulda/matchers"
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
 module Features
   # Extend this module in spec/support/features/*.rb
@@ -21,20 +21,3 @@ end
 
 ActiveRecord::Migration.maintain_test_schema!
 Capybara.javascript_driver = :webkit
-
-require "webmock/rspec"
-
-# http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-RSpec.configure do |config|
-  config.expect_with :rspec do |expectations|
-    expectations.syntax = :expect
-  end
-
-  config.mock_with :rspec do |mocks|
-    mocks.syntax = :expect
-  end
-
-  config.order = :random
-end
-
-WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Previously, the spec/support files were required in the order determined by the development OS, which was causing issues across environments.  Updated the rails_helper to require the files in the same order regardless of environment.

* Upgrade airbrake.
* Always set the Rails environment to "Test" when testing.
* Removed duplicate spec configuration from rails_helper.

https://trello.com/c/OPSbJ2AE

![](http://www.reactiongifs.com/r/spg.gif)