### PR TITLE
Rename development rake task to avoid confusion

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -2,7 +2,7 @@ if Rails.env.development? || Rails.env.test?
   require "factory_girl"
 
   namespace :dev do
-    desc "Seed data for development environment"
+    desc "Sample data for local development environment"
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 


### PR DESCRIPTION
Previously, the development rake task was adding "seed" data, which was not actually data required for the Production site to run, but was just to get an example Development environment running. Renamed the Rake task to better reflect this.

https://trello.com/c/7X0O6ZfA

![](http://www.reactiongifs.com/r/mmb1.gif)