### PR TITLE
Add ctags configuration dotfile per project basis

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,2 @@
+--recurse=yes
+--exclude=vendor


### PR DESCRIPTION
Previously, there was no ctags configuration defined for the application, which meant that we were reliant on the global configuration defined by the developer's environment. Added a project-specific configuration to allow greater control.

https://trello.com/c/f88yJCAK

![](http://www.reactiongifs.com/r/trmp2.gif)