### PR TITLE
Rename $HOST to $APPLICATION_HOST

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,9 +1,9 @@
 # http://ddollar.github.com/foreman/
+APPLICATION_HOST=localhost:9000
 ASSET_HOST=localhost:9000
 ASSETS_VERSION=1.0
 AWS_ACCESS_KEY_ID=development_aws_access
 AWS_SECRET_ACCESS_KEY=development_aws_secret
-HOST=localhost:9000
 RACK_ENV=development
 S3_BUCKET_NAME=local-radfords-assets
 S3_HOST_NAME=s3-eu-west-1.amazonaws.com

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.middleware.use Rack::Deflater
 
   # Ensure requests are only served from one, canonical host name
-  config.middleware.use Rack::CanonicalHost, ENV.fetch("HOST")
+  config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -70,7 +70,7 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV.fetch(
     "ASSET_HOST",
-    ENV.fetch("HOST")
+    ENV.fetch("APPLICATION_HOST")
   )
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -94,6 +94,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APPLICATION_HOST")
+  }
 end
 Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -7,5 +7,7 @@ Mail.register_interceptor(
 Rails.application.configure do
   # ...
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APPLICATION_HOST")
+  }
 end


### PR DESCRIPTION
Previously, we were using the `$HOST` environment variable to set the root domain of the site, which was conflicting with the zsh environment variable. Changed the variable name to one that won't conflict.

https://trello.com/c/v4Sj67h8

![](http://www.reactiongifs.com/r/whtt.gif)