### PR TITLE
Do not accept XML as a default input

### DIFF
--- a/config/initializers/disable_xml_params.rb
+++ b/config/initializers/disable_xml_params.rb
@@ -1,0 +1,1 @@
+ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)


### PR DESCRIPTION
Previously, we were accepting XML as a default input, which was opening us up to potential security vulnerabilities. Added XML to the list of disabled input types.

https://trello.com/c/upVEWM94

![](http://www.reactiongifs.com/r/dnno2.gif)