### PR TITLE
Remove comments and newlines in config files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../boot', __FILE__)
-
 require "rails"
-# Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
@@ -9,16 +7,10 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
-
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-
 module Radfords
   class Application < Rails::Application
     config.i18n.enforce_available_locales = true
-
     config.generators do |generate|
       generate.helper false
       generate.javascript_engine false
@@ -28,23 +20,8 @@ module Radfords
       generate.test_framework :rspec
       generate.view_specs false
     end
-
     config.action_controller.action_on_unpermitted_parameters = :raise
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
     config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,2 @@
-# Load the rails application
 require File.expand_path('../application', __FILE__)
-
-# Initialize the rails application
-Radfords::Application.initialize!
+Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,45 +1,15 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in
-  # config/application.rb.
-
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
-
-  # Do not eager load code on boot.
   config.eager_load = false
-
-  # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-
-  # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :test
-
-  # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
-
-  # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
-
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
   config.assets.debug = true
-
-  # Asset digests allow you to set far-future HTTP expiration dates on all
-  # assets, yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
-
-  # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
-
   config.action_mailer.default_url_options = { host: "localhost:9000" }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,99 +1,26 @@
 require Rails.root.join("config/smtp")
 Rails.application.configure do
-  # Settings specified here will take precedence over those in
-  # config/application.rb.
-
-  # Code is not reloaded between requests.
   config.cache_classes = true
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
-
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  # config.action_dispatch.rack_cache = true
-
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
   config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
-  config.static_cache_control = "public, max-age=#{1.year.to_i}"
-  # Enable deflate / gzip compression of controller-generated responses
   config.middleware.use Rack::Deflater
-
-  # Ensure requests are only served from one, canonical host name
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
-
-  # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
-
-  # Asset digests allow you to set far-future HTTP expiration dates on all
-  # assets, yet still be able to expire them through the digest params.
   config.assets.digest = true
-
-  # `config.assets.precompile` and `config.assets.version` have moved to
-  # config/initializers/assets.rb
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use
-  # secure cookies.
-  # config.force_ssl = true
-
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
   config.log_level = :debug
-
-  # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   config.action_controller.asset_host = ENV.fetch(
     "ASSET_HOST",
     ENV.fetch("APPLICATION_HOST")
   )
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to
-  # raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = SMTP_SETTINGS
-
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
-
-  # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
   config.action_mailer.default_url_options = {
     host: ENV.fetch("APPLICATION_HOST")
   }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,47 +1,16 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in
-  # config/application.rb.
-
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
-
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
-
-  # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files = true
+  config.serve_static_files   = true
   config.static_cache_control = "public, max-age=3600"
-
-  # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-
-  # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
-
-  # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-
-  # Randomize the order test cases are executed.
   config.active_support.test_order = :random
-
-  # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-
-  # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
-
   config.action_mailer.default_url_options = { host: "www.example.com" }
-
   config.active_job.queue_adapter = :inline
 end


### PR DESCRIPTION
Previously, all of the comments and newlines were present in the config files, which was just adding noise. Removed them all.

https://trello.com/c/Ou1rAOPh

![](http://www.reactiongifs.com/r/aawt.gif)