### PR TITLE
Add RSpec guard against truncating Production DB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       sass (>= 3.3)
     netrc (0.10.3)
     newrelic_rpm (3.14.1.311)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
     paperclip (4.2.2)
@@ -389,4 +389,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
+abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
 require "shoulda/matchers"


### PR DESCRIPTION
Previously, there were no checks in place to make sure that Rails specs weren't run in the Production environment, which meant that the Production database could accidentally be truncated. Added a guard to the Rails helper to stop tests from being run in the Production environment.

https://trello.com/c/cCqNrTA2

![](http://www.reactiongifs.com/r/jty.gif)