### PR TITLE
Configure capybara-webkit to block unknown URLs

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,4 +1,6 @@
 # http://ddollar.github.com/foreman/
+AIRBRAKE_API_KEY=development_airbrake_project_key
+AIRBRAKE_PROJECT_ID=development_airbrake_project_id
 APPLICATION_HOST=localhost:9000
 ASSET_HOST=localhost:9000
 ASSETS_VERSION=1.0

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit", ">= 1.2.0"
+  gem "capybara-webkit"
   gem "cucumber-rails", require: false
   gem "database_cleaner"
   gem "formulaic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,12 +37,12 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    airbrake (4.3.4)
-      builder
-      multi_json
+    airbrake (5.0.0)
+      airbrake-ruby (~> 1.0)
+    airbrake-ruby (1.0.0)
     arel (6.0.3)
-    ast (2.1.0)
-    autoprefixer-rails (6.1.2)
+    ast (2.2.0)
+    autoprefixer-rails (6.2.1)
       execjs
       json
     awesome_print (1.6.1)
@@ -73,10 +73,10 @@ GEM
     cocaine (0.5.7)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
-    coffee-rails (4.1.0)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.3.0)
+      railties (>= 4.0.0, < 5.1.x)
+    coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
@@ -275,9 +275,9 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (3.0.1)
       activesupport (>= 4.0.0)
-    simple_form (3.2.0)
-      actionpack (~> 4.0)
-      activemodel (~> 4.0)
+    simple_form (3.2.1)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
     simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -341,7 +341,7 @@ DEPENDENCIES
   bourbon (~> 4.2.0)
   bundler-audit
   byebug
-  capybara-webkit (>= 1.2.0)
+  capybara-webkit
   coffee-rails (~> 4.1.0)
   cucumber-rails
   database_cleaner

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,4 @@
 Airbrake.configure do |config|
-  config.api_key = ENV['AIRBRAKE_API_KEY']
+  config.project_key = ENV["AIRBRAKE_API_KEY"]
+  config.project_id = ENV["AIRBRAKE_PROJECT_ID"]
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,9 @@ module Features
 end
 
 RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.block_unknown_urls
+  end
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Previously, there were some issues with some of the JavaScript tests that hit external URLs, which was causing the suite to fail erroneously. Removed the limit on capybara-webkit and configured the suite to block unknown URLs.

* Upgraded airbrake, ast, autoprefixer-rails, coffee-rails, coffee-script, and simple_form

https://trello.com/c/ibuSc23D

![](http://www.reactiongifs.com/r/dmbrdy.gif)