### PR TITLE
Fix Circle deploys by removing redundant remote

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,5 +11,4 @@ deployment:
   staging:
     branch: master
     commands:
-      - git remote add staging git@heroku.com:radfords-qa.git
       - bin/deploy staging


### PR DESCRIPTION
Previously, Circle was trying to add a Git remote that had already been added in the setup, which was causing the build to fail and stopping the app from automatically deploying. Removed the redundant remote from the configuration.

https://trello.com/c/4IxdWs1f

![](http://www.reactiongifs.com/r/wwhet.gif)