### PR TITLE
Provide Shoulda Matchers config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
-  gem "shoulda-matchers", require: false
+  gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     addressable (2.4.0)
     airbrake (5.0.1)
       airbrake-ruby (~> 1.0)
-    airbrake-ruby (1.0.0)
+    airbrake-ruby (1.0.1)
     arel (6.0.3)
     ast (2.2.0)
     autoprefixer-rails (6.2.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
-require "shoulda/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 

--- a/spec/support/shoulda_matchers_config.rb
+++ b/spec/support/shoulda_matchers_config.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Previously, there was no configuration for Shoulda Matchers, which was causing strange errors to be raised that were difficult to decipher. Added a configuration to the Rails helper.

* Updated airbrake-ruby.

https://trello.com/c/MCfNMNbE

![](http://www.reactiongifs.com/r/ctdh.gif)