### PR TITLE
Install Foreman automatically in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -27,8 +27,7 @@ if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
 fi
 
 if ! command -v foreman > /dev/null; then
-  printf 'Foreman is not installed.\n'
-  printf 'See https://github.com/ddollar/foreman for install instructions.\n'
+  gem install foreman
 fi
 
 # Only if this isn't CI


### PR DESCRIPTION
Previously, the setup script would warn the developer when Foreman was not installed, which meant that some developers were missing the message and not understanding why the application wouldn't run. Updated the setup script to automatically install foreman.

https://trello.com/c/vLyS3ghV

![](http://www.reactiongifs.com/r/ctdh.gif)