### PR TITLE
Reduce number of Puma processes and threads

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,8 +3,17 @@
 # The environment variable WEB_CONCURRENCY may be set to a default value based
 # on dyno size. To manually configure this value use heroku config:set
 # WEB_CONCURRENCY.
-workers Integer(ENV.fetch("WEB_CONCURRENCY", 3))
-threads_count = Integer(ENV.fetch("MAX_THREADS", 5))
+#
+# Increasing the number of workers will increase the amount of resting memory
+# your dynos use. Increasing the number of threads will increase the amount of
+# potential bloat added to your dynos when they are responding to heavy
+# requests.
+#
+# Starting with a low number of workers and threads provides adequate
+# performance for most applications, even under load, while maintaining a low
+# risk of overusing memory.
+workers Integer(ENV.fetch("WEB_CONCURRENCY", 2))
+threads_count = Integer(ENV.fetch("MAX_THREADS", 2))
 threads(threads_count, threads_count)
 
 preload_app!


### PR DESCRIPTION
Previously, the Puma processes and threads were set up in such a way, which opened us up to some potential memory issues. Updated the configuration to provide us with reasonable performance with plenty of room to go.

https://trello.com/c/b1Cm1VHC

![](http://www.reactiongifs.com/r/omgshoop.gif)