### PR TITLE
Add quiet_assets as development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "title"
 gem "uglifier"
 
 group :development do
+  gem "quiet_assets"
   gem "refills"
   gem "spring"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    airbrake (5.0.1)
+    airbrake (5.0.2)
       airbrake-ruby (~> 1.0)
-    airbrake-ruby (1.0.1)
+    airbrake-ruby (1.0.2)
     arel (6.0.3)
     ast (2.2.0)
     autoprefixer-rails (6.2.3)
@@ -207,6 +207,8 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (2.15.3)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-canonical-host (0.1.0)
       addressable
@@ -367,6 +369,7 @@ DEPENDENCIES
   pg
   pry-rails
   puma
+  quiet_assets
   rack-canonical-host
   rack-timeout
   rails (~> 4.2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ Bundler.require(*Rails.groups)
 module Radfords
   class Application < Rails::Application
     config.i18n.enforce_available_locales = true
+    config.quiet_assets = true
     config.generators do |generate|
       generate.helper false
       generate.javascript_engine false


### PR DESCRIPTION
Previously, all of the asset pipeline debugging was being included in the development logs, which was adding quite a lot of noise. Added the quiet_assets gem to the development gem group.

* Upgraded airbrake and airbrake-ruby

https://trello.com/c/6LSjYFF5

![](http://www.reactiongifs.com/r/cwtf.gif)