### PR TITLE
Fix deprecation warning from capybara-webkit

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,9 +13,6 @@ module Features
 end
 
 RSpec.configure do |config|
-  config.before(:each, js: true) do
-    page.driver.block_unknown_urls
-  end
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
@@ -23,4 +20,3 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,0 +1,2 @@
+Capybara.javascript_driver = :webkit
+Capybara::Webkit.configure(&:block_unknown_urls)


### PR DESCRIPTION
Previously, the configuration for capybara-webkit was defined in the Rails helper, which was causing deprecation warnings to be raised. The configuration has been moved into a separate spec support file.

https://trello.com/c/921oNzp3

![](http://www.reactiongifs.com/r/mog2.gif)