### PR TITLE
Don't configure action_mailer_host in staging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.4.0)
+    addressable (2.3.8)
     airbrake (5.0.2)
       airbrake-ruby (~> 1.0)
     airbrake-ruby (1.0.2)
@@ -325,8 +325,8 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.22.3)
-      addressable (>= 2.3.6)
+    webmock (1.22.5)
+      addressable (< 2.4.0)
       crack (>= 0.3.2)
       hashdiff
     xpath (2.0.0)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -6,8 +6,4 @@ Mail.register_interceptor(
 
 Rails.application.configure do
   # ...
-
-  config.action_mailer.default_url_options = {
-    host: ENV.fetch("APPLICATION_HOST")
-  }
 end


### PR DESCRIPTION
Previously, we were explicitly setting `action_mailer_host` for the staging environment, which was already using the same value set in the production environment. Removed the duplicate line from the staging configuration.

* Upgraded addressable and webmock

https://trello.com/c/15C6RPdR

![](http://www.reactiongifs.com/r/elnino.gif)