### PR TITLE
Cleanup generated `bin/setup` file

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,7 +16,7 @@ if [ ! -f .env ]; then
 fi
 
 # Set up database and add any development seed data
-bundle exec rake db:setup dev:prime
+bin/rake dev:prime
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe


### PR DESCRIPTION
Currently, we are setting up the database before we prime it and priming inside bundler, which are both not necessary. Removed the set up of the database and used the rake binstup to prime the development environment.

https://trello.com/c/phMrTaCS

![](http://www.reactiongifs.com/r/agtmbomg.gif)