### PR TITLE
Configure Circle to use Rake binstub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ database:
     - bin/setup
 test:
   override:
-    - bundle exec rake
+    - bin/rake
 deployment:
   staging:
     branch: master


### PR DESCRIPTION
Previously, the Circle build was using the bundled version of Rake, which is not required now that we have a binstubbed version. Updated the Circle configuration to use the binstub.

https://trello.com/c/CWAi6trV

![](http://www.reactiongifs.com/r/frz.gif)