### PR TITLE
Add bullet as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "bullet"
   gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     airbrake (5.0.2)
       airbrake-ruby (~> 1.0)
     airbrake-ruby (1.0.2)
@@ -55,6 +55,9 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
+    bullet (5.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -318,13 +321,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    uniform_notifier (1.9.0)
     vcr (2.9.3)
     web-console (3.0.0)
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.22.5)
-      addressable (< 2.4.0)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
     xpath (2.0.0)
@@ -339,6 +343,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk
   bourbon (~> 4.2.0)
+  bullet
   bundler-audit
   byebug
   capybara-webkit

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,6 +4,11 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end
   config.action_mailer.delivery_method = :test
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load


### PR DESCRIPTION
Previously, we had no way of knowing if we were making inefficient ActiveRecord queries, which was opening us up to potential performance issues. Added bullet as a development dependency.

* Updated addressable and webmock.

https://trello.com/c/dKKqx38z

![](http://www.reactiongifs.com/r/dhc.gif)