### PR TITLE
Use Heroku Local (Forego) instead of Foreman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.swp
 /.bundle
 /.env
-/.foreman
 /coverage/*
 /db/*.sqlite3
 /log/*

--- a/.sample.env
+++ b/.sample.env
@@ -1,4 +1,4 @@
-# http://ddollar.github.com/foreman/
+# https://github.com/ddollar/forego
 AIRBRAKE_API_KEY=development_airbrake_project_key
 AIRBRAKE_PROJECT_ID=development_airbrake_project_id
 APPLICATION_HOST=localhost:9000

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    shoulda-matchers (3.0.1)
+    shoulda-matchers (3.1.0)
       activesupport (>= 4.0.0)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ your machine with [this script].
 
 [this script]: https://github.com/thoughtbot/laptop
 
-After setting up, you can run the application using [foreman]:
+After setting up, you can run the application using [Heroku Local]:
 
-    % foreman start
+    % heroku local
 
-If you don't have `foreman`, see [Foreman's install instructions][foreman]. It
-is [purposefully excluded from the project's `Gemfile`][exclude].
-
-[foreman]: https://github.com/ddollar/foreman
-[exclude]: https://github.com/ddollar/foreman/pull/437#issuecomment-41110407
+[Heroku Local]: https://devcenter.heroku.com/articles/heroku-local
 
 ## Guidelines
 

--- a/bin/setup
+++ b/bin/setup
@@ -21,15 +21,6 @@ bin/rake dev:prime
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
-# Pick a port for Foreman
-if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
-  printf 'port: 9000\n' >> .foreman
-fi
-
-if ! command -v foreman > /dev/null; then
-  gem install foreman
-fi
-
 # Only if this isn't CI
 # if [ -z "$CI" ]; then
 # fi


### PR DESCRIPTION
Previously, we were using Foreman to manage our applications, which has now been replaced with Forego in the Heroku stack. Replaced Foreman with Forego.

* Updated shoulda-matchers.

https://trello.com/c/bz2QOHJR

![](http://www.reactiongifs.com/r/oowwtl.gif)