### PR TITLE
Raise on missing Sprockets assets in test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
     safe_yaml (1.0.4)
-    sass (3.4.20)
+    sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.assets.raise_runtime_errors = true
   config.cache_classes = true
   config.eager_load = false
   config.serve_static_files   = true


### PR DESCRIPTION
Previously, there were no checks on Sprockets assets, which meant that we didn't know anything was wrong until an error was raised in the browser. Added a check into the Test environment to make sure all Sprockets assets are present.

* Updated sass.

https://trello.com/c/reqcos2o

![](http://www.reactiongifs.com/r/smhn.gif)