### PR TITLE
Set default app to staging

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       parser (>= 2.2.3.0)
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
-    jquery-rails (4.0.5)
+    jquery-rails (4.1.0)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -242,7 +242,7 @@ GEM
       activesupport (= 4.2.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rake (10.5.0)
     recipient_interceptor (0.1.2)
       mail
     refills (0.1.0)

--- a/bin/setup
+++ b/bin/setup
@@ -29,3 +29,4 @@ mkdir -p .git/safe
 git remote add staging git@heroku.com:radfords-qa.git || true
 git remote add production git@heroku.com:radfords-production.git || true
 
+git config heroku.remote staging


### PR DESCRIPTION
Previously, there was no default Heroku application specified, which meant that you always had to declare which environment you were deploying to. Updated the git configuration to make Staging the default Heroku application.

* Updated jquery-rails and rake.

https://trello.com/c/YBYA96pj

![](http://www.reactiongifs.com/r/awsm.gif)