### PR TITLE
Ignore `.env.local` instead of `.env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.swo
 *.swp
 /.bundle
-/.env
+/.env.local
 /coverage/*
 /db/*.sqlite3
 /log/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     airbrake-ruby (1.0.2)
     arel (6.0.3)
     ast (2.2.0)
-    autoprefixer-rails (6.2.3)
+    autoprefixer-rails (6.3.1)
       execjs
       json
     awesome_print (1.6.1)
@@ -199,8 +199,8 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.3)
       mime-types
-    parser (2.2.3.0)
-      ast (>= 1.1, < 3.0)
+    parser (2.3.0.1)
+      ast (~> 2.2)
     pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)


### PR DESCRIPTION
Previously, we were storing environment variables in `.sample.env` to be copied into `.env` at a later date, which was causing the test suite to fail when the variables weren't copied across. Added `.env` to the repository.

* Updated autoprefixer-rails and parser.

https://trello.com/c/yEkLVgXz

![](http://www.reactiongifs.com/r/mmb1.gif)