### PR TITLE
Add lang attribute to html element in layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />


### PR DESCRIPTION
Previously, we were not specifying the language that the HTML document was being presented in, which made it difficult for accessibility tools to correctly render the site. Added the `lang` attribute to the top-level HTML element. 

https://trello.com/c/AxDBLe1V

![](http://www.reactiongifs.com/r/drngd.gif)