### PR TITLE
Set puma workers to 1 in .sample.env

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -19,3 +19,4 @@ SMTP_PASSWORD=development_smtp_password
 SMTP_USERNAME=development_smtp_username
 STRIPE_PUBLISHABLE_KEY=development_stripe_pk
 STRIPE_SECRET_KEY=development_stripe_sk
+WEB_CONCURRENCY=1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.2)
     timecop (0.7.1)
-    tins (1.8.1)
+    tins (1.8.2)
     title (0.0.5)
       i18n
       rails (>= 3.1)


### PR DESCRIPTION
Previously, the number of puma workers wasn't being set, which was causing sessions to be dropped in web-console. Specified that there should be one puma worker in the development environment.

* Updated tins

https://trello.com/c/LXMu9oRL

![](http://www.reactiongifs.com/r/trmp2.gif)