### PR TITLE
Add pry-byebug to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,10 +43,10 @@ group :development, :test do
   gem "awesome_print"
   gem "bullet"
   gem "bundler-audit", require: false
-  gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "i18n-tasks"
+  gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.3.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,14 +62,15 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.1)
-    capybara (2.4.4)
+    capybara (2.6.0)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.7.1)
-      capybara (>= 2.3.0, < 2.6.0)
+    capybara-webkit (1.8.0)
+      capybara (>= 2.3.0, < 2.7.0)
       json
     climate_control (0.0.3)
       activesupport (>= 3.0)
@@ -174,7 +175,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.99)
     mini_portile2 (2.0.0)
-    minitest (5.8.3)
+    minitest (5.8.4)
     monetize (1.1.0)
       money (~> 6.5.0)
     money (6.5.1)
@@ -206,6 +207,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (2.15.3)
@@ -346,7 +350,6 @@ DEPENDENCIES
   bourbon (~> 4.2.0)
   bullet
   bundler-audit
-  byebug
   capybara-webkit
   coffee-rails (~> 4.1.0)
   cucumber-rails
@@ -370,6 +373,7 @@ DEPENDENCIES
   normalize-rails (~> 3.0.0)
   paperclip
   pg
+  pry-byebug
   pry-rails
   puma
   quiet_assets


### PR DESCRIPTION
Previously, we were including the byebug gem on it's own, which meant we didn't have access to some extra functionality. Added the pre-byebug gem.

* Updated capybara, capybara-webkit, and minitest.

https://trello.com/c/c3cXKGEo

![](http://www.reactiongifs.com/r/tms.gif)