### PR TITLE
Add warning configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       airbrake-ruby (~> 1.0)
     airbrake-ruby (1.0.4)
     arel (6.0.3)
-    autoprefixer-rails (6.3.2)
+    autoprefixer-rails (6.3.3)
       execjs
       json
     awesome_print (1.6.1)

--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -1,0 +1,34 @@
+require "net/http"
+require "net/smtp"
+
+# Example:
+#   begin
+#     some http call
+#   rescue *HTTP_ERRORS => error
+#     notify_hoptoad error
+#   end
+
+HTTP_ERRORS = [
+  EOFError,
+  Errno::ECONNRESET,
+  Errno::EINVAL,
+  Net::HTTPBadResponse,
+  Net::HTTPHeaderSyntaxError,
+  Net::ProtocolError,
+  Timeout::Error
+].freeze
+
+SMTP_SERVER_ERRORS = [
+  IOError,
+  Net::SMTPAuthenticationError,
+  Net::SMTPServerBusy,
+  Net::SMTPUnknownError,
+  Timeout::Error
+].freeze
+
+SMTP_CLIENT_ERRORS = [
+  Net::SMTPFatalError,
+  Net::SMTPSyntaxError
+].freeze
+
+SMTP_ERRORS = SMTP_SERVER_ERRORS + SMTP_CLIENT_ERRORS


### PR DESCRIPTION
Previously, we had no way of grouping similar exceptions together, which meant that we would be rescue the wrong thing or implementing multiple rescues unnecessarily. Added a warning configuration to catch similar exceptions.

* Updated autoprefixer-rails.

https://trello.com/c/l2hk9vS0