### PR TITLE
Update array style in line with guide

### DIFF
--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -15,7 +15,7 @@ HTTP_ERRORS = [
   Net::HTTPBadResponse,
   Net::HTTPHeaderSyntaxError,
   Net::ProtocolError,
-  Timeout::Error
+  Timeout::Error,
 ].freeze
 
 SMTP_SERVER_ERRORS = [
@@ -23,12 +23,12 @@ SMTP_SERVER_ERRORS = [
   Net::SMTPAuthenticationError,
   Net::SMTPServerBusy,
   Net::SMTPUnknownError,
-  Timeout::Error
+  Timeout::Error,
 ].freeze
 
 SMTP_CLIENT_ERRORS = [
   Net::SMTPFatalError,
-  Net::SMTPSyntaxError
+  Net::SMTPSyntaxError,
 ].freeze
 
 SMTP_ERRORS = SMTP_SERVER_ERRORS + SMTP_CLIENT_ERRORS


### PR DESCRIPTION
Previously, we were not putting a comma on the end of multi-line array elements, which is not in line with best practices. Added a trailing comma to the last element of every multi-line array in the errors initializer.

https://trello.com/c/hJj3R2Va