### PR TITLE
Remove the fix_i18n_deprecation_warning method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rspec-core (3.4.2)
+    rspec-core (3.4.3)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -307,7 +307,7 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.23.0)
+    webmock (1.24.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -12,8 +12,8 @@ fi
 heroku pg:backups restore \
   `heroku pg:backups public-url -a radfords-qa` \
   DATABASE_URL \
-  --confirm radfords-staging-pr-$1 \
-  --app radfords-staging-pr-$1
-heroku run rake db:migrate --app radfords-staging-pr-$1
-heroku ps:scale worker=1 --app radfords-staging-pr-$1
-heroku restart --app radfords-staging-pr-$1
+  --confirm radfords-qa-pr-$1 \
+  --app radfords-qa-pr-$1
+heroku run rake db:migrate --app radfords-qa-pr-$1
+heroku ps:scale worker=1 --app radfords-qa-pr-$1
+heroku restart --app radfords-qa-pr-$1

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,6 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 module Radfords
   class Application < Rails::Application
-    config.i18n.enforce_available_locales = true
     config.quiet_assets = true
     config.generators do |generate|
       generate.helper false

--- a/db/migrate/20140122173612_monetise_product.rb
+++ b/db/migrate/20140122173612_monetise_product.rb
@@ -1,7 +1,7 @@
 class MonetiseProduct < ActiveRecord::Migration
   def up
     remove_column :products, :price
-    add_money :products, :price
+    add_monetize :products, :price
   end
 
   def down


### PR DESCRIPTION
Previously, we were explicitly telling the application to enforce available locales, which is now done by default since Rails 4.1. Removed the explicit setting from the application configuration.

* Updated rspec-core and webmock.

https://trello.com/c/AXe2saXP