### PR TITLE
Add spec for order's line items

### DIFF
--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -128,6 +128,17 @@ describe Order do
     end
   end
 
+  describe "#line_items" do
+    let(:basket) { double("Basket", line_items: items) }
+    let(:items) { [] }
+
+    before { allow(order).to receive(:basket).and_return(basket) }
+
+    it "returns the basket's line items" do
+      expect(order.line_items).to be(items)
+    end
+  end
+
   describe "#make_address" do
     let(:address_line_1) { "1 Bro Deg" }
     let(:made_address) { [address_line_1].join("\n") }


### PR DESCRIPTION
Previously, there were no tests around `Order`'s `line_items` functionality, which meant that we never knew if it was functioning as expected. Added a unit test for `Order#line_items`.

https://trello.com/c/4U4vy3Zl