### PR TITLE
Add a spec for deleting suppliers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       i18n
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
-    geocoder (1.2.6)
+    geocoder (1.3.1)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.6)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,3 +86,5 @@ en:
     application: "Radfords of Somerford"
     baskets:
       show: "Your Basket"
+    pages:
+      outlets: "Outlets"

--- a/spec/features/events/new_spec.rb
+++ b/spec/features/events/new_spec.rb
@@ -10,17 +10,12 @@ module Features
       )
     end
 
-    let(:email) { user.email }
     let(:name) { "Maker's Market" }
     let(:location) { "Sandbach" }
-    let(:password) { user.password }
-    let(:signin_page) { SigninPage.new(email, password) }
     let(:takes_place_on) { Date.tomorrow.strftime("%e %B %Y") }
-    let(:user) { FactoryGirl.create(:user) }
 
     it "successfully creates an event" do
-      visit signin_path
-      signin_page.sign_in
+      sign_in
       new_event_page.visit
 
       new_event_page.create

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -2,17 +2,12 @@ require "rails_helper"
 
 module Features
   describe 'fulfil order' do
-    let(:email) { user.email }
     let(:order) { FactoryGirl.create(:order) }
     let(:order_page) { OrderPage.new(order) }
     let(:mail) { ActionMailer::Base.deliveries.last }
-    let(:password) { user.password }
-    let(:signin_page) { SigninPage.new(email, password) }
-    let(:user) { FactoryGirl.create(:user) }
 
     it 'sends an email to the customer' do
-      visit signin_path
-      signin_page.sign_in
+      sign_in
 
       order_page.visit_page
       order_page.fulfil

--- a/spec/features/suppliers/deleting_spec.rb
+++ b/spec/features/suppliers/deleting_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+module Features
+  describe "deleting orders" do
+    it "deletes existing order" do
+      VCR.use_cassette("google maps") do
+        FactoryGirl.create(:supplier)
+      end
+
+      sign_in
+      visit outlets_url
+
+      click_button("Delete")
+
+      expect(page).to have_title("Outlets")
+      expect(page).to have_text("You successfully deleted the supplier.")
+    end
+  end
+end

--- a/spec/support/cassettes/google_maps.yml
+++ b/spec/support/cassettes/google_maps.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=4%20Buckingham%20Road,%20Thorpe%20Larches%20TS21%206FF&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 25 Feb 2016 12:01:09 GMT
+      Expires:
+      - Fri, 26 Feb 2016 12:01:09 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '65'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [],
+           "status" : "ZERO_RESULTS"
+        }
+    http_version: 
+  recorded_at: Thu, 25 Feb 2016 12:01:09 GMT
+recorded_with: VCR 2.9.3

--- a/spec/support/radfords.rb
+++ b/spec/support/radfords.rb
@@ -1,0 +1,13 @@
+module RadfordsTestHelpers
+  def sign_in
+    user = FactoryGirl.create(:user)
+    page = SigninPage.new(user.email, user.password)
+
+    page.visit
+    page.sign_in
+  end
+end
+
+module Features
+  include RadfordsTestHelpers
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,4 @@
+VCR.configure do |c|
+  c.cassette_library_dir = Rails.root.join("spec", "support", "cassettes")
+  c.hook_into :webmock
+end


### PR DESCRIPTION
Previously, there was no integration test around the deleting suppliers functionality, which meant that we could have no confidence that any of our changes were working and weren't breaking existing functionality. Added a feature spec for deleting suppliers.

* Updated geocoder.
* Defined a title for the "Outlets" page.
* Extracted signing in logic into a helper module.
* Configured VCR.

https://trello.com/c/Tyl4rgxm