### PR TITLE
Add APPLICATION_HOST to app.json file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     bullet (5.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
-    bundler-audit (0.4.0)
+    bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (8.2.2)
@@ -168,7 +168,7 @@ GEM
       railties (>= 3.0)
     multi_json (1.11.2)
     multi_test (0.1.1)
-    neat (1.7.2)
+    neat (1.7.3)
       bourbon (>= 4.0)
       sass (>= 3.3)
     netrc (0.10.3)
@@ -308,7 +308,7 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.24.1)
+    webmock (1.24.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/app.json
+++ b/app.json
@@ -2,6 +2,9 @@
   "name":"radfords",
   "scripts":{},
   "env":{
+    "APPLICATION_HOST":{
+      "required":true
+    },
     "EMAIL_RECIPIENTS":{
       "required":true
     },


### PR DESCRIPTION
Previously, we were not setting the `APPLICATION_HOST` for the Review applications, which meant that the canonical host was not being set correctly. Added `APPLICATION_HOST` to `app.json`.

https://trello.com/c/DQ3MmuuX