### PR TITLE
Disable CSS transitions in tests

### DIFF
--- a/app/views/application/_css_overrides.html.erb
+++ b/app/views/application/_css_overrides.html.erb
@@ -1,0 +1,8 @@
+<% if Rails.env.test? %>
+  <style type="text/css">
+    * {
+      transition-property: none !important;
+      -webkit-transition-property: none !important;
+    }
+  </style>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,5 +24,6 @@
     <%= render "layouts/footer" %>
   </div>
   <%= render "javascript" %>
+  <%= render "css_overrides" %>
 </body>
 </html>


### PR DESCRIPTION
Previously, CSS transitions were enabled in tests, which could sometimes lead to slow JavaScript tests. Added a `css_overrides` partial to the application layout to disable the transitions in the Test environment.

https://trello.com/c/wSMllx4Y