### PR TITLE
bundler-audit >= 0.5.0 so vulnerability db updates fail loudly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "bullet"
-  gem "bundler-audit", require: false
+  gem "bundler-audit", ">= 0.5.0", require: false
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ DEPENDENCIES
   aws-sdk
   bourbon (~> 4.2.0)
   bullet
-  bundler-audit
+  bundler-audit (>= 0.5.0)
   capybara-webkit
   coffee-rails (~> 4.1.0)
   cucumber-rails


### PR DESCRIPTION
Since 0.5.0, bundle-audit update returns a non-zero exit status on error. With earlier versions, bundle audit check would still pass after a vulnerability db update failure.

https://trello.com/c/9ueEwFo9