### PR TITLE
Add an integration test for Suppliers new

### DIFF
--- a/spec/features/suppliers/create_spec.rb
+++ b/spec/features/suppliers/create_spec.rb
@@ -11,6 +11,8 @@ module Features
         click_button("Create Supplier")
       end
 
+      expect(page).to have_text("You successfully created a supplier.")
+      expect(page).to have_text("Delicatessens / Farm Shops")
       expect(page).to have_text(name)
     end
 

--- a/spec/features/suppliers/create_spec.rb
+++ b/spec/features/suppliers/create_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+module Features
+  describe "creating a supplier" do
+    it "creates a new supplier" do
+      sign_in
+      visit new_supplier_url
+
+      VCR.use_cassette("google maps") do
+        fill_form(:supplier, attributes_for(:supplier))
+        click_button("Create Supplier")
+      end
+
+      expect(page).to have_text(name)
+    end
+
+    def name
+      attributes_for(:supplier)[:name]
+    end
+  end
+end


### PR DESCRIPTION
Improve test coverage by covering what happens;

```
When I visit the outlets page
Given I am signed in
Then I click 'New' to create a new supplier
```

![](https://media.giphy.com/media/p26ylSePJM12g/giphy.gif)
