### PR TITLE
Remove `RAILS_ENV` declarations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.24.3)
+    webmock (1.24.5)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/app.json
+++ b/app.json
@@ -20,9 +20,6 @@
     "RACK_ENV":{
       "required":true
     },
-    "RAILS_ENV":{
-      "required":true
-    },
     "S3_BUCKET_NAME":{
       "required":true
     },

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-ENV["RAILS_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]


### PR DESCRIPTION
Previously, we were using `RAILS_ENV` to ascertain the current Rails environment, which is not in line with best practices. `RAILS_ENV` has been replaced with `Rails.env`, which checks `RAILS_ENV` and falls back to `RACK_ENV`.

* Updated webmock.

https://trello.com/c/s6G1hmey