### PR TITLE
Drop support for IE 9, IE 10, and iOS 7

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,4 +1,3 @@
 Last 2 versions
-Explorer >= 9
-iOS >= 7.1
+Explorer >= 11
 Android >= 4.4


### PR DESCRIPTION
Previously, we were supporting versions of Internet Explorer from 9 upwards and versions of iOS from 7.1 upwards, which now account for a minimal amount of traffic globally. Updated the supported browser list to versions of Internet Explorer from 11 upwards and the most modern iOS.

https://trello.com/c/38jZUSXm