### PR TITLE
Store test email output as files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.2.4)
+    byebug (8.2.5)
     capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
@@ -169,7 +169,7 @@ GEM
       bourbon (>= 4.0)
       sass (>= 3.3)
     netrc (0.10.3)
-    newrelic_rpm (3.15.1.316)
+    newrelic_rpm (3.15.2.317)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
@@ -308,7 +308,7 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (1.24.5)
+    webmock (2.0.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.rails_logger = true
   end
-  config.action_mailer.delivery_method = :test
+  config.action_mailer.delivery_method = :file
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load
   config.assets.debug = true


### PR DESCRIPTION
Previously, we were storing test email output in the log files, which meant that the developer had to go scrolling through the logs to find the appropriate content. The `delivery_method` has been changed to `:file` so that the content is stored in separate files for each email address.

* Updated byebug, newrelic_rpm, and webmock.

https://trello.com/c/eRFdaO6P

![](http://i.giphy.com/MMQrQQ87G2MmY.gif)