### PR TITLE
Update CSS overrides

### DIFF
--- a/app/views/application/_css_overrides.html.erb
+++ b/app/views/application/_css_overrides.html.erb
@@ -2,7 +2,6 @@
   <style type="text/css">
     * {
       transition-property: none !important;
-      -webkit-transition-property: none !important;
     }
   </style>
 <% end %>


### PR DESCRIPTION
Previously, we were include a Webkit-specific transition definition, which is only required for versions of iOS older than iOS 6. We removed the unsupported transition definition from the CSS overrides.

https://trello.com/c/3CLb1mUX

![](http://i.giphy.com/26h0p1QEEMLzymZlC.gif)