### PR TITLE
Return exit code from Heroku

### DIFF
--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -14,6 +14,6 @@ heroku pg:backups restore \
   DATABASE_URL \
   --confirm radfords-qa-pr-$1 \
   --app radfords-qa-pr-$1
-heroku run rake db:migrate --app radfords-qa-pr-$1
+heroku run rake db:migrate --exit-code --app radfords-qa-pr-$1
 heroku ps:scale worker=1 --app radfords-qa-pr-$1
 heroku restart --app radfords-qa-pr-$1


### PR DESCRIPTION
Previously, Heroku was not returning the exit code from the commands run via the review setup script, which meant that migrations would often fail to run when setting up a review application. Updated the set up review app script to return the exit code from commands run on Heroku.

https://trello.com/c/IXoloH2M

![](http://i.giphy.com/ZLhjGpX4PKI7u.gif)