### PR TITLE
Remove the staging environment

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,9 +1,0 @@
-require_relative "production"
-
-Mail.register_interceptor(
-  RecipientInterceptor.new(ENV.fetch("EMAIL_RECIPIENTS"))
-)
-
-Rails.application.configure do
-  # ...
-end

--- a/config/smtp.rb
+++ b/config/smtp.rb
@@ -7,3 +7,7 @@ SMTP_SETTINGS = {
   port: "587",
   user_name: ENV.fetch("SMTP_USERNAME")
 }
+
+if ENV["EMAIL_RECIPIENTS"].present?
+  Mail.register_interceptor RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])
+end


### PR DESCRIPTION
Previously, we had a separate environment configuration for the Staging environment, which was exactly the same as the Production environment apart from some Recipient Interceptor settings. Removed the Staging environment configuration and enabled Recipient Interceptor based on an environment variable.

https://trello.com/c/ZvYH1NP8

![](http://i.giphy.com/Av2gvzNdpWBHy.gif)