### PR TITLE
Drop initialiser for disabling the XML parser

### DIFF
--- a/config/initializers/disable_xml_params.rb
+++ b/config/initializers/disable_xml_params.rb
@@ -1,1 +1,0 @@
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)


### PR DESCRIPTION
Previously, we had to remove the XML parser from the default parser list because of a security vulnerability, which has now been resolved. Dropped the now unnecessary initialiser from the application.

https://trello.com/c/BUDYxGKG

![](http://i.giphy.com/rmt6Kd7ZAYcV2.gif)