### PR TITLE
Tweak Heroku setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,6 @@ group :test do
 end
 
 group :staging, :production do
-  gem "rails_stdout_logging"
   gem "rack-timeout"
+  gem "rails_stdout_logging"
 end

--- a/bin/deploy
+++ b/bin/deploy
@@ -8,5 +8,5 @@ branch="$(git symbolic-ref HEAD --short)"
 target="${1:-staging}"
 
 git push "$target" "$branch:master"
-heroku run rake db:migrate --remote "$target"
+heroku run rake db:migrate --exit-code --remote "$target"
 heroku restart --remote "$target"


### PR DESCRIPTION
Previously, the deploy script was not waiting for the exit code from Heroku, which meant the deploy come sometimes fail. Updated the script to request the exit code from Heroku.

https://trello.com/c/nSnvFTd5

![](http://i.giphy.com/3o6ozisefTf0tasaOs.gif)