### PR TITLE
Add integration test for updating suppliers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
     submit:
       product:
         create: "Create Product"
+      supplier:
+        update: "Update Supplier"
   layouts:
     header:
       basket: "Basket (%{item_count})"

--- a/spec/features/suppliers/updating_spec.rb
+++ b/spec/features/suppliers/updating_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe "updating suppliers" do
+  it "successfully updates" do
+    supplier = VCR.use_cassette("google maps") do
+      FactoryGirl.create(:supplier)
+    end
+
+    sign_in
+    visit edit_supplier_url(supplier)
+
+    VCR.use_cassette("google maps") do
+      fill_form_and_submit(:supplier, :edit, attributes_for(:supplier))
+    end
+
+    expect(page).to have_title("Outlets")
+    expect(page).to have_content(supplier.address)
+    expect(page).to have_content(supplier.name)
+    expect(page).to have_content(supplier.telephone_number)
+    expect(page).to have_content(supplier.website)
+  end
+end


### PR DESCRIPTION
Previously, there were no integration tests for updating suppliers, which meant that when we made any changes we wouldn't know if we had broken existing functionality. Added tests around updating suppliers.

https://trello.com/c/YBBceAC3

![](http://i.giphy.com/6cFcUiCG5eONW.gif)