### PR TITLE
Configure `static_cache_control` for Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
       rest-client (~> 1.4)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.3)
     timecop (0.8.1)
     title (0.0.5)
       i18n
@@ -375,5 +375,8 @@ DEPENDENCIES
   web-console
   webmock
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,6 +9,7 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.serve_static_files = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.static_cache_control = "public, max-age=31557600"
   config.middleware.use Rack::Deflater
   config.assets.js_compressor = :uglifier
   config.assets.compile = false


### PR DESCRIPTION
Previously, we weren't caching static assets in Production, which meant that the assets were being served directly from the server every time and therefore affecting site performance. Set the static cache to one year from the last time it was loaded.

* Updated tilt

https://trello.com/c/30d0UOq5

![](http://i.giphy.com/l396QDhpJiPd1ETpC.gif)