### PR TITLE
Upgrade bourbon to 5.0.0.beta.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.3.1"
 
 gem "autoprefixer-rails"
 gem "aws-sdk"
-gem "bourbon", "5.0.0.beta.5"
+gem "bourbon", "5.0.0.beta.6"
 gem "delayed_job_active_record"
 gem "draper"
 gem "flutie"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,9 +38,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
-    autoprefixer-rails (6.3.6.1)
+    autoprefixer-rails (6.3.6.2)
       execjs
-    awesome_print (1.6.1)
+    awesome_print (1.7.0)
     aws-sdk (1.59.0)
       aws-sdk-v1 (= 1.59.0)
     aws-sdk-v1 (1.59.0)
@@ -54,9 +54,9 @@ GEM
       bourbon (>= 5.0.0.beta.3)
       sass (~> 3.4)
       thor (~> 0.19)
-    bourbon (5.0.0.beta.5)
-      sass (~> 3.4)
-      thor (~> 0.19)
+    bourbon (5.0.0.beta.6)
+      sass (~> 3.4.22)
+      thor (~> 0.19.1)
     builder (3.2.2)
     bullet (5.1.0)
       activesupport (>= 3.0.0)
@@ -64,7 +64,7 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (9.0.4)
+    byebug (9.0.5)
     capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
@@ -229,7 +229,7 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.1.2)
+    rake (11.2.2)
     recipient_interceptor (0.1.2)
       mail
     refills (0.1.0)
@@ -273,7 +273,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    skylight (0.10.3)
+    skylight (0.10.4)
       activesupport (>= 3.0.0)
     slop (3.6.0)
     spring (1.7.1)
@@ -294,13 +294,13 @@ GEM
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
       rest-client (~> 1.4)
-    suspenders (1.38.1)
+    suspenders (1.39.0)
       bitters (~> 1.3)
       bundler (~> 1.3)
       rails (~> 4.2.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.4)
+    tilt (2.0.5)
     timecop (0.8.1)
     title (0.0.5)
       i18n
@@ -314,11 +314,11 @@ GEM
     unf_ext (0.0.7.1)
     uniform_notifier (1.10.0)
     vcr (2.9.3)
-    web-console (3.1.1)
+    web-console (3.3.0)
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
-    webmock (2.0.3)
+    webmock (2.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -332,7 +332,7 @@ DEPENDENCIES
   autoprefixer-rails
   awesome_print
   aws-sdk
-  bourbon (= 5.0.0.beta.5)
+  bourbon (= 5.0.0.beta.6)
   bullet
   bundler-audit (>= 0.5.0)
   capybara-webkit


### PR DESCRIPTION
* Updated autoprefixer-rails, awesome_print, byebug, rake, skylight, suspenders, tilt, web-console, and webmock

https://trello.com/c/oXy5QJaW

![](http://i.giphy.com/l0OWjzSZEROpjIqRi.gif)