### PR TITLE
Introduce a stylesheet_base generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby "2.3.1"
 
 gem "autoprefixer-rails"
 gem "aws-sdk"
-gem "bourbon", "5.0.0.beta.6"
 gem "delayed_job_active_record"
 gem "draper"
 gem "flutie"
@@ -14,7 +13,6 @@ gem "honeybadger"
 gem "jquery-rails"
 gem "kaminari"
 gem "money-rails"
-gem "neat", "~> 1.7.0"
 gem "normalize-rails", "~> 3.0.0"
 gem "paperclip"
 gem "pg"
@@ -47,7 +45,6 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "refills"
   gem "rspec-rails", "~> 3.4.0"
 end
 
@@ -72,3 +69,7 @@ group :staging, :production do
   gem "rack-timeout"
   gem "rails_stdout_logging"
 end
+
+gem "bourbon", "5.0.0.beta.6"
+gem "neat", "~> 1.7.0"
+gem "refills", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
     spring (1.7.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.6.0)
+    sprockets (3.6.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.0)


### PR DESCRIPTION
This introduces the `suspenders:stylesheet_base` generator, which adds our typical foundations for CSS. In this case it is Bourbon, Neat, and Refills.

Of note, the `application.scss` must list the imports in a specific order, and this removes the `application.css`.

https://trello.com/c/T4hCB0Uc

![](http://i.giphy.com/3o72FhOuMPynKHOI92.gif)