### PR TITLE
APPLICATION_HOST bug fix in production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,9 @@
 require Rails.root.join("config/smtp")
 Rails.application.configure do
+  if ENV.fetch("HEROKU_APP_NAME", "").include?("qa-pr-")
+    ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
+  end
+  config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false
@@ -19,10 +23,6 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
-  if ENV.fetch("HEROKU_APP_NAME", "").include?("qa-pr-")
-    ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
-  end
-  config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
   config.middleware.use Rack::Deflater
   config.static_cache_control = "public, max-age=31557600"
   config.action_mailer.default_url_options = {


### PR DESCRIPTION
`ENV["APPLICATION_HOST"]` is used before it's defined in the production environment.

By using `inject_into_file` instead of `configure_environment` we can control the order of the steps.

https://trello.com/c/2rIrTx1E

![](http://i.giphy.com/xT4uQfHn1CUGyYsiiY.gif)