### PR TITLE
Add a integration test for missing events

### DIFF
--- a/spec/features/events/show_spec.rb
+++ b/spec/features/events/show_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe "show event" do
+  context "when the event does not exist" do
+    before { sign_in }
+
+    it "shows the 'Events' page" do
+      expect(Event.count).to be_zero
+
+      visit event_url(1)
+
+      expect(page).to have_title(I18n.t("titles.events.index"))
+      expect(page).to have_content(I18n.t("events.not_found"))
+    end
+  end
+end


### PR DESCRIPTION
Previously, there were no tests around the 'Event' page for scenarios where the event did not exist, which meant that we could not make any functionality changes and be 100% confident that we had not broken any existing functionality. Added an integration test around the 'Event' page functionality for scenarios when the event does not exist.

https://trello.com/c/T3fE8DoF

![](http://i.giphy.com/26BRzJmX5rH5Jbzuo.gif)