### PR TITLE
Install heroku-deflater

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ RACK_ENV=development
 RACK_MINI_PROFILER=0
 S3_BUCKET_NAME=local-radfords-assets
 S3_HOST_NAME=s3-eu-west-1.amazonaws.com
+S3_REGION=development-s3-region
 SECRET_KEY_BASE=development_secret
 SEGMENT_IO_KEY=development_segment
 SMTP_ADDRESS=smtp.example.com

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "2.3.1"
 
 gem "autoprefixer-rails"
-gem "aws-sdk-v1"
+gem "aws-sdk"
 gem "delayed_job_active_record"
 gem "draper"
 gem "flutie"
@@ -65,6 +65,7 @@ group :test do
 end
 
 group :staging, :production do
+  gem "heroku-deflater"
   gem "rack-timeout"
   gem "rails_stdout_logging"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,12 @@ GEM
     autoprefixer-rails (6.3.6.2)
       execjs
     awesome_print (1.7.0)
-    aws-sdk-v1 (1.66.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
+    aws-sdk (2.3.19)
+      aws-sdk-resources (= 2.3.19)
+    aws-sdk-core (2.3.19)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.3.19)
+      aws-sdk-core (= 2.3.19)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -119,16 +122,21 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
+    heroku-deflater (0.6.2)
+      rack (>= 1.4.5)
     high_voltage (3.0.0)
     honeybadger (2.6.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    json_pure (2.0.1)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -140,7 +148,7 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.2)
-    mimemagic (0.3.0)
+    mimemagic (0.3.1)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     monetize (1.4.0)
@@ -161,12 +169,12 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     normalize-rails (3.0.3)
-    paperclip (4.3.6)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
+    paperclip (5.0.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
       cocaine (~> 0.5.5)
       mime-types
-      mimemagic (= 0.3.0)
+      mimemagic (~> 0.3.0)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.3)
@@ -243,8 +251,8 @@ GEM
     rspec-support (3.4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.5)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -263,10 +271,10 @@ GEM
     skylight (0.10.5)
       activesupport (>= 3.0.0)
     slop (3.6.0)
-    spring (1.7.1)
+    spring (1.7.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.6.2)
+    sprockets (3.6.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-es6 (0.9.0)
@@ -316,7 +324,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   awesome_print
-  aws-sdk-v1
+  aws-sdk
   bourbon (= 5.0.0.beta.6)
   bullet
   bundler-audit (>= 0.5.0)
@@ -330,6 +338,7 @@ DEPENDENCIES
   formulaic
   friendly_id
   geocoder
+  heroku-deflater
   high_voltage
   honeybadger
   jquery-rails

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,6 +13,7 @@ class Product < ActiveRecord::Base
     },
     s3_host_name: ENV['S3_HOST_NAME'],
     s3_protocol: "",
+    s3_region: ENV["S3_REGION"],
     style: {
       order_summary: "70x70#",
       preview: "50x50#",

--- a/spec/support/cassettes/aws.yml
+++ b/spec/support/cassettes/aws.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://local-radfords-assets.s3-eu-west-1.amazonaws.com/products/photos/000/000/001/original/photo.jpg
+    uri: https://local-radfords-assets.s3.development-s3-region.amazonaws.com/products/photos/000/000/001/original/photo.jpg
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4031,7 +4031,7 @@ http_interactions:
   recorded_at: Sat, 27 Feb 2016 20:19:50 GMT
 - request:
     method: put
-    uri: https://local-radfords-assets.s3-eu-west-1.amazonaws.com/products/photos/000/000/110/order_summary/photo.jpg
+    uri: https://local-radfords-assets.s3.development-s3-region.amazonaws.com/products/photos/000/000/110/order_summary/photo.jpg
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4366,7 +4366,7 @@ http_interactions:
   recorded_at: Sat, 27 Feb 2016 20:19:51 GMT
 - request:
     method: put
-    uri: https://local-radfords-assets.s3-eu-west-1.amazonaws.com/products/photos/000/000/110/preview/photo.jpg
+    uri: https://local-radfords-assets.s3.development-s3-region.amazonaws.com/products/photos/000/000/110/preview/photo.jpg
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -4645,7 +4645,7 @@ http_interactions:
   recorded_at: Sat, 27 Feb 2016 20:19:51 GMT
 - request:
     method: put
-    uri: https://local-radfords-assets.s3-eu-west-1.amazonaws.com/products/photos/000/000/110/show/photo.jpg
+    uri: https://local-radfords-assets.s3.development-s3-region.amazonaws.com/products/photos/000/000/110/show/photo.jpg
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -8517,7 +8517,7 @@ http_interactions:
   recorded_at: Sat, 27 Feb 2016 20:19:52 GMT
 - request:
     method: put
-    uri: https://local-radfords-assets.s3-eu-west-1.amazonaws.com/products/photos/000/000/110/thumbnail/photo.jpg
+    uri: https://local-radfords-assets.s3.development-s3-region.amazonaws.com/products/photos/000/000/110/thumbnail/photo.jpg
     body:
       encoding: ASCII-8BIT
       string: !binary |-


### PR DESCRIPTION
Previously, none of the site's assets were being compressed, which was causing the site to load at sub-optimal speeds. Install heroku-deflator to gzip assets in the Production environment.

* Updated mimemagic, paperclip, sass-rails, spring, and sprockets.
* Replaced aws-sdk-v1 with aws-sdk.
* Added S3 region to Product and environment variables.
* Updated AWS VCR cassette to use the new S3 URL.

https://trello.com/c/1Zcnu8sQ

![](http://i.giphy.com/l4HoaTxnFw3RH1p7y.gif)