### PR TITLE
Remove duplicate refills requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "refills"
   gem "rspec-rails", "~> 3.5.0.beta4"
 end
 


### PR DESCRIPTION
Before, we were including refills in the Gemfile twice, which is unnecessary. Removed the duplicate entry.

![](http://i.giphy.com/xUySTQrznWtO9pWxVe.gif)