### PR TITLE
Prefer using `public_file_server.headers`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,14 +9,11 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
-  config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=31557600"
-  }
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.action_controller.asset_host = ENV.fetch(
     "ASSET_HOST",
-    ENV.fetch("APPLICATION_HOST"),
+    ENV.fetch("APPLICATION_HOST")
   )
   config.log_level = :debug
   config.log_tags = [:request_id]
@@ -33,8 +30,11 @@ Rails.application.configure do
   end
   config.active_record.dump_schema_after_migration = false
   config.middleware.use Rack::Deflater
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=31557600",
+  }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("APPLICATION_HOST"),
+    host: ENV.fetch("APPLICATION_HOST")
   }
 end
 Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i


### PR DESCRIPTION
Before, a deprecation warning was being raised when deploying to the Production environment. Replaced `static_cache_control` with `public_file_server.headers` in the Production configuration.

![](http://i.giphy.com/l3vRny6tXZXdRyZ0I.gif)