### PR TITLE
Remove Turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+
 //= require_tree .


### PR DESCRIPTION
Before, turbolinks were being included in the application's JavaScript file. They are not currently used by the application. Removed turbolinks.

![](http://i.giphy.com/IjPL01jSz7wBi.gif)