### PR TITLE
Update generator configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module Radfords
     config.assets.quiet = true
     config.generators do |generate|
       generate.helper false
-      generate.javascript_engine false
+      generate.javascripts false
       generate.request_specs false
       generate.routing_specs false
       generate.stylesheets false


### PR DESCRIPTION
Before, the generator configuration used `javascript_engine false`. This raised warnings when generating a scaffold. Replaced the line with `javascripts false`.

![](http://i.giphy.com/Z6dFBeTbA8QjS.gif)