### PR TITLE
Update RSpec Rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.5.0.beta4"
+  gem "rspec-rails", "~> 3.5"
 end
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ DEPENDENCIES
   rails_stdout_logging
   recipient_interceptor
   refills
-  rspec-rails (~> 3.5.0.beta4)
+  rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   shoulda-matchers
   simple_form


### PR DESCRIPTION
Before, the application was using a beta version of the RSpec Rails gem. This version is now stable. Updated the gem to the 3.5

![](http://i.giphy.com/l0MYDPG9tpIv0Ffe8.gif)