### PR TITLE
Update SimpleForm initialiser

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -9,7 +9,7 @@ SimpleForm.setup do |config|
     :default,
     class: :input,
     hint_class: :field_with_hint,
-    error_class: :field_with_errors,
+    error_class: :field_with_errors
   ) do |b|
     ## Extensions enabled by default
     # Any of these extensions can be disabled for a
@@ -32,7 +32,11 @@ SimpleForm.setup do |config|
     # extensions by default, you can change `b.optional` to `b.use`.
 
     # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
     b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
 
     # Calculates pattern from format validations for string inputs
     b.optional :pattern


### PR DESCRIPTION
Before, the SimpleForm initialiser only contained details for calculating a field's greatest length. Added a configuration to also calculate smallest length. Also added more comments to the file.

![](http://i.giphy.com/l2YWjq7JY3XGJ2uZ2.gif)