### PR TITLE
Remove Rails Stdout Logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ end
 group :staging, :production do
   gem "heroku-deflater"
   gem "rack-timeout"
-  gem "rails_stdout_logging"
 end
 
 gem 'high_voltage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,6 @@ GEM
       nokogiri (~> 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_stdout_logging (0.0.5)
     railties (5.0.1)
       actionpack (= 5.0.1)
       activesupport (= 5.0.1)
@@ -366,7 +365,6 @@ DEPENDENCIES
   rack-mini-profiler
   rack-timeout
   rails (~> 5.0.0)
-  rails_stdout_logging
   recipient_interceptor
   refills
   rspec-rails (~> 3.5)


### PR DESCRIPTION
Before, we included Heroku's Rails Stdout Logging gem, to follow their 12factor method. This is now included with Rails 5 so we no longer needed to add it ourselves.

![](http://i.giphy.com/l0ErFIGQSbzPcxKfe.gif)