### PR TITLE
🔧 Make the application run Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: [ ]


### PR DESCRIPTION
Before, we had to check for updated gems by running `bundler outdated`. If we forgot to run this command, our dependencies would become outdated. This opened us up to potential security vulnerabilities. We made the application run Dependabot to automate this process.
