### PR TITLE
🐛 Fix the Stripe implementation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bin/auto_migrate
 web: bundle exec puma -p $PORT -C ./config/puma.rb
 worker: bundle exec rake jobs:work

--- a/app.json
+++ b/app.json
@@ -1,46 +1,14 @@
 {
-  "name":"radfords",
-  "scripts":{},
-  "env":{
-    "APPLICATION_HOST":{
-      "required":true
-    },
-    "AWS_ACCESS_KEY_ID": { "required": true },
-    "AWS_SECRET_ACCESS_KEY": { "required": true },
-    "EMAIL_RECIPIENTS":{
-      "required":true
-    },
-    "HEROKU_APP_NAME": {
-      "required":true
-    },
-    "HEROKU_PARENT_APP_NAME": {
-      "required":true
-    },
-    "HONEYBADGER_API_KEY":{
-      "required":true
-    },
-    "RACK_ENV":{
-      "required":true
-    },
-    "S3_BUCKET_NAME":{ "required": true, "value": "radfords-review" },
-    "S3_REGION": { "required": true },
-    "SECRET_KEY_BASE":{
-      "generator":"secret"
-    },
-    "SMTP_ADDRESS":{
-      "required":true
-    },
-    "SMTP_DOMAIN":{
-      "required":true
-    },
-    "SMTP_PASSWORD":{
-      "required":true
-    },
-    "SMTP_USERNAME":{
-      "required":true
-    }
-  },
-  "addons":[
+  "addons": [
     "heroku-postgresql"
-  ]
+  ],
+  "env": {
+    "AUTO_MIGRATE_DB": "true",
+    "SMTP_ADDRESS": "smtp.example.com",
+    "SMTP_DOMAIN": "example.com",
+    "SMTP_PASSWORD": "password",
+    "SMTP_USERNAME": "username",
+    "ROBS_ENV": "yes"
+  },
+  "stack": "heroku-20"
 }

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -3,6 +3,8 @@ class LineItem < ActiveRecord::Base
   belongs_to :order
   belongs_to :product
 
+  validates :basket, presence: true
+  validates :product, presence: true
   validates :quantity, numericality: { greater_than: 0 }
 
   scope :by_created_at, -> { order(:created_at) }

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -1,0 +1,65 @@
+class OrderForm
+  include ActiveModel::Model
+
+  attr_accessor(
+    :address_city,
+    :address_county,
+    :address_line_1,
+    :address_post_code,
+    :basket,
+    :card_cvc,
+    :card_exp_month,
+    :card_exp_year,
+    :card_number,
+    :email,
+    :name,
+  )
+
+  validates :address_city, presence: true
+  validates :address_line_1, presence: true
+  validates :address_post_code, presence: true
+  validates :name, presence: true
+  validates :email, presence: true
+
+  def self.model_name
+    ActiveModel::Name.new(self, nil, "Order")
+  end
+
+  def id
+    if @order.present?
+      @order.id
+    end
+  end
+
+  def save
+    if valid?
+      OrderBuilder.build(create_order, create_card)
+      true
+    else
+      false
+    end
+  end
+
+  private
+
+  def create_order
+    @order = Order.create(
+      address_city: address_city,
+      address_post_code: address_post_code,
+      basket: basket,
+      email: email,
+      name: name,
+    )
+  end
+
+  def create_card
+    Stripe::Token.create(
+      card: {
+        number: card_number,
+        exp_month: card_exp_month,
+        exp_year: card_exp_year,
+        cvc: card_cvc,
+      },
+    )
+  end
+end

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -71,10 +71,9 @@
 
   <div class="fieldset">
     <div class="field">
-      <%= label_tag(nil, t(".card_number")) %>
-      <%= text_field_tag(
-        nil,
-        nil,
+      <%= f.label(:card_number) %>
+      <%= f.text_field(
+        :card_number,
         class: "card-number",
         data: { stripe: "number" },
         placeholder: t(".card_number")
@@ -85,16 +84,14 @@
       <%= label_tag(nil, t(".expiration")) %>
 
       <div class="select-group">
-        <%= text_field_tag(
-          nil,
-          nil,
+        <%= f.text_field(
+          :card_exp_month,
           class: "card-expiry-month",
           data: { stripe: "exp-month" },
           placeholder: t(".exp_month")
         ) %>
-        <%= text_field_tag(
-          nil,
-          nil,
+        <%= f.text_field(
+          :card_exp_year,
           class: "card-expiry-year",
           data: { stripe: "exp-year" },
           placeholder: t(".exp_year")
@@ -103,10 +100,9 @@
     </div>
 
     <div class="field">
-      <%= label_tag(nil, t(".cvc")) %>
-      <%= text_field_tag(
-        nil,
-        nil,
+      <%= f.label(:card_cvc) %>
+      <%= f.text_field(
+        :card_cvc,
         class: "card-cvc",
         data: { stripe: "cvc" },
         placeholder: t(".cvc")

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -59,11 +59,3 @@
     </div>
   </div>
 </div>
-
-<%= content_for(:javascript) do %>
-  <%= javascript_include_tag('https://js.stripe.com/v2/') %>
-
-  <script type="text/javascript">
-    Stripe.setPublishableKey('<%= Rails.configuration.stripe[:publishable_key] %>');
-  </script>
-<% end %>

--- a/bin/auto_migrate
+++ b/bin/auto_migrate
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Running the auto migration"
+
+if [ -n "$AUTO_MIGRATE_DB" ]; then
+  bundle exec rake db:migrate
+fi

--- a/bin/setup
+++ b/bin/setup
@@ -10,15 +10,17 @@ set -e
 gem install bundler --conservative
 bundle check || bundle install
 
-# Set up database and add any development seed data
-bin/rake dev:prime
+# Set up database
+bin/rails db:setup
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
 # Only if this isn't CI
-# if [ -z "$CI" ]; then
-# fi
+if [ -z "$CI" ]; then
+  # Add any development seed data
+  bin/rake dev:prime
+fi
 
 git remote add staging git@heroku.com:radfords-qa.git || true
 git remote add production git@heroku.com:radfords-production.git || true

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -7,6 +7,7 @@ if Rails.env.development? || Rails.env.test?
       include FactoryGirl::Syntax::Methods
 
       create(:user, email: "admin@example.com", password: "password")
+      create(:product, price: Money.new(5_00))
     end
   end
 end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -36,7 +36,7 @@ describe OrdersController do
     let(:invalid_options) { invalid_params.merge("basket" => basket) }
     let(:invalid_order) { Order.new }
     let(:invalid_params) { { "name" => "" } }
-    let(:order) { double("Order", id: id, save!: nil) }
+    let(:order) { double("Order", id: id, save: true) }
     let(:order_options) { order_params.merge("basket" => basket) }
     let(:order_params) { { "name" => "Alphonso Quigley" } }
     let(:params) { { "order" => order_params, "stripe_token" => stripe_token } }
@@ -51,16 +51,8 @@ describe OrdersController do
       allow(OrderBuilder).to receive(:build).with(order, stripe_token)
     end
 
-    it "builds the order" do
-      allow(Order).to receive(:new).and_return(order)
-
-      post :create, params: params
-
-      expect(OrderBuilder).to have_received(:build).with(order, stripe_token)
-    end
-
     it "deletes the basket ID from the session" do
-      allow(Order).to receive(:new).and_return(order)
+      allow(OrderForm).to receive(:new).and_return(order)
 
       post :create, params: params
 
@@ -68,7 +60,7 @@ describe OrdersController do
     end
 
     it "adds the order ID to the session" do
-      allow(Order).to receive(:new).and_return(order)
+      allow(OrderForm).to receive(:new).and_return(order)
 
       post :create, params: params
 
@@ -76,7 +68,7 @@ describe OrdersController do
     end
 
     it "sets the flash" do
-      allow(Order).to receive(:new).and_return(order)
+      allow(OrderForm).to receive(:new).and_return(order)
 
       post :create, params: params
 
@@ -84,7 +76,7 @@ describe OrdersController do
     end
 
     it "redirects the the homepage" do
-      allow(Order).to receive(:new).and_return(order)
+      allow(OrderForm).to receive(:new).and_return(order)
 
       post :create, params: params
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,6 +10,15 @@ FactoryGirl.define do
     location "Town Hall, Macclesfield"
   end
 
+  factory :line_item do
+    basket
+    product { build(:product, price: price) }
+
+    transient do
+      price { Money.new(5_00) }
+    end
+  end
+
   factory :user do
     name 'Robert Whittaker'
     email 'purinkle@example.com'

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -13,9 +13,11 @@ module Features
 
       fill_form(:order, :new, attributes_for(:order))
 
-      VCR.use_cassette("stripe/customers") do
-        VCR.use_cassette("stripe/charges") do
-          click_button("Place my order")
+      VCR.use_cassette("stripe/tokens") do
+        VCR.use_cassette("stripe/customers") do
+          VCR.use_cassette("stripe/charges") do
+            click_button("Place my order")
+          end
         end
       end
 

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -3,6 +3,14 @@ require "rails_helper"
 describe LineItem do
   let(:item) { LineItem.new }
 
+  describe "validations" do
+    subject { build(:line_item) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:basket) }
+    it { is_expected.to validate_presence_of(:product) }
+  end
+
   describe '#total_price' do
     subject { item.total_price }
 

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -1,0 +1,217 @@
+require "rails_helper"
+
+RSpec.describe OrderForm do
+  it { is_expected.to validate_presence_of(:address_city) }
+  it { is_expected.to validate_presence_of(:address_line_1) }
+  it { is_expected.to validate_presence_of(:address_post_code) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:email) }
+
+  describe ".model_name" do
+    it "is the form's naming-related information" do
+      model_name = OrderForm.model_name
+
+      expect(model_name).to have_attributes(
+        cache_key: "orders",
+        collection: "orders",
+        element: "order",
+        i18n_key: :order,
+        name: "Order",
+        param_key: "order",
+        plural: "orders",
+        route_key: "orders",
+        singular: "order",
+      )
+    end
+  end
+
+  describe "#id" do
+    it "is nil" do
+      form = build_form
+
+      id = form.id
+
+      expect(id).to be_nil
+    end
+
+    context "when we've saved the form" do
+      it "is the ID of the created order" do
+        form = build_form
+        form.save
+
+        id = form.id
+
+        expect(id).to eq Order.last.id
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when the form is valid" do
+      it "is true" do
+        form = build_form
+
+        save = form.save
+
+        expect(save).to be(true)
+      end
+
+      it "creates a new order" do
+        basket = create_basket(5_00)
+        form = build_form(
+          address_city: "Testville",
+          address_post_code: "TE5 7TE",
+          basket: basket,
+          email: "customer@example.com",
+          name: "Test Customer",
+        )
+
+        form.save
+
+        expect(Order.last).to have_attributes(
+          address: <<~"ADDRESS".chomp,
+            Testville
+            TE5 7TE
+          ADDRESS
+          basket: basket,
+          email: "customer@example.com",
+          name: "Test Customer",
+        )
+      end
+
+      it "charges the customer" do
+        form = build_form(
+          basket: create_basket(5_00),
+          customer_id: "TEST_CUSTOMER_ID",
+        )
+
+        form.save
+
+        expect(Stripe::Charge).to have_received(:create).with(
+          amount: 5_00,
+          currency: "gbp",
+          customer: "TEST_CUSTOMER_ID",
+          description: /Payment for #\d+/,
+        )
+      end
+
+      it "sends an 'order received' mail" do
+        form = build_form
+
+        form.save
+
+        expect(ActionMailer::Base.deliveries.count).to eq 1
+      end
+    end
+
+    context "when the form is invalid" do
+      it "is false" do
+        form = build_form(name: "")
+
+        save = form.save
+
+        expect(save).to be(false)
+      end
+
+      it "doesn't create any orders" do
+        form = build_form(name: "")
+
+        form.save
+
+        expect(Order.last).to be_nil
+      end
+
+      it "doesn't charge the customer" do
+        form = build_form(name: "")
+
+        form.save
+
+        expect(Stripe::Charge).not_to have_received(:create)
+      end
+
+      it "doesn't send an 'order received' mail" do
+        form = build_form(name: "")
+
+        form.save
+
+        expect(ActionMailer::Base.deliveries.count).to be_zero
+      end
+    end
+  end
+
+  def build_form(
+    address_city: "Testville",
+    address_line_1: "1 Test Street",
+    address_post_code: "TE5 7TE",
+    basket: create_basket,
+    card_cvc: "817",
+    card_exp_month: "10",
+    card_exp_year: "2023",
+    card_number: "4242424242424242",
+    customer_id: "TEST_CUSTOMER_ID",
+    email: "customer@example.com",
+    name: "Test Customer"
+  )
+    stub_charge(
+      amount: basket.total_price.cents,
+      customer: stub_customer(
+        card: stub_card(
+          cvc: card_cvc,
+          exp_month: card_exp_month,
+          exp_year: card_exp_year,
+          number: card_number,
+        ),
+        email: email,
+        id: customer_id,
+      ),
+    )
+    OrderForm.new(
+      address_city: address_city,
+      address_line_1: address_line_1,
+      address_post_code: address_post_code,
+      basket: basket,
+      card_cvc: card_cvc,
+      card_exp_month: card_exp_month,
+      card_exp_year: card_exp_year,
+      card_number: card_number,
+      email: email,
+      name: name,
+    )
+  end
+
+  def create_basket(amount = 5_00)
+    create(:line_item, price: Money.new(amount)).basket
+  end
+
+  def stub_card(cvc:, exp_month:, exp_year:, number:)
+    double(:card).tap do |card|
+      allow(Stripe::Token).to receive(:create).with(
+        card: {
+          cvc: cvc,
+          exp_month: exp_month,
+          exp_year: exp_year,
+          number: number,
+        },
+      ).and_return(card)
+    end
+  end
+
+  def stub_customer(card:, email:, id:)
+    double(:customer, id: id).tap do |customer|
+      allow(Stripe::Customer).to receive(:create).with(
+        card: card,
+        description: /Customer for #\d+/,
+        email: email,
+      ).and_return(customer)
+    end
+  end
+
+  def stub_charge(amount:, customer:)
+    allow(Stripe::Charge).to receive(:create).with(
+      amount: amount,
+      currency: "gbp",
+      customer: customer.id,
+      description: /Payment for #\d+/,
+    )
+  end
+end

--- a/spec/support/aws.rb
+++ b/spec/support/aws.rb
@@ -1,0 +1,1 @@
+Aws.config[:s3] = { stub_responses: true }

--- a/spec/support/cassettes/stripe/tokens.yml
+++ b/spec/support/cassettes/stripe/tokens.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/tokens
+    body:
+      encoding: UTF-8
+      string: description=Customer%20for%20%2369&email=alphonso.quigley%40example.com
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Stripe/v1 RubyBindings/1.16.0
+      Authorization:
+      - Bearer development_stripe_sk
+      Content-Type:
+      - application/x-www-form-urlencoded
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.16.0","lang":"ruby","lang_version":"2.3.1 p112 (2016-04-26)","platform":"x86_64-darwin14","publisher":"stripe","uname":"Darwin
+        Robs-MacBook-Pro.local 14.5.0 Darwin Kernel Version 14.5.0: Thu Apr 21 20:40:54
+        PDT 2016; root:xnu-2782.50.3~1/RELEASE_X86_64 x86_64"}'
+      Content-Length:
+      - '71'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 01 Jun 2016 08:18:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '123'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Stripe-Version:
+      - '2016-03-07'
+      Www-Authenticate:
+      - Bearer realm="Stripe"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "tok_1LuYZrEP7Asam48w2pCU0r23",
+          "object": "token",
+          "card": {
+            "id": "card_1LuYZrEP7Asam48woceUF79R",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "cvc_check": "unchecked",
+            "dynamic_last4": null,
+            "exp_month": 10,
+            "exp_year": 2023,
+            "fingerprint": "0xaLmZI0YSmjyH3E",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": null,
+            "tokenization_method": null
+          },
+          "client_ip": "82.69.120.215",
+          "created": 1666171723,
+          "livemode": false,
+          "type": "card",
+          "used": false
+        }
+    http_version:
+  recorded_at: Wed, 01 Jun 2016 08:18:55 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Before, we may have had too much trust in the test suite. We hadn't checked the application in the browser for a while, and things weren't as rosy as we had assumed. We had not covered the old JavaScript Stripe implementation in a feature spec. As you may have guessed, this approach no longer worked. We fixed the order creation flow to only use the server side.

- Added a spec helper to stub out HTTP requests to AWS S3.
- Added a product to the developer Rake task.
