### PR TITLE
🐛 Fix the email sender's address

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -11,7 +11,7 @@ class Mailer < ActionMailer::Base
   def order_shipped(order)
     @order = order
     mail(
-      from: 'rob@purinkle.co.uk',
+      from: "rob@purinkle.co.uk",
       subject: "Shipping confirmation for order #{order.id}",
       to: @order.email
     )

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -11,7 +11,7 @@ class Mailer < ActionMailer::Base
   def order_shipped(order)
     @order = order
     mail(
-      from: 'denise@radfordsofsomerford.co.uk',
+      from: 'rob@purinkle.co.uk',
       subject: "Shipping confirmation for order #{order.id}",
       to: @order.email
     )
@@ -20,6 +20,6 @@ class Mailer < ActionMailer::Base
   private
 
   def denise
-    "denise@radfordsofsomerford.co.uk"
+    "rob@purinkle.co.uk"
   end
 end

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -13,7 +13,7 @@ module Features
       order_page.fulfil
 
       expect(mail.to).to eql([order.email])
-      expect(mail.from).to eql(['rob@purinkle.co.uk'])
+      expect(mail.from).to eql(["rob@purinkle.co.uk"])
       expect(mail.subject).to eql("Shipping confirmation for order #{order.id}")
       expect(page).to have_content('email sent')
     end

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -13,7 +13,7 @@ module Features
       order_page.fulfil
 
       expect(mail.to).to eql([order.email])
-      expect(mail.from).to eql(['denise@radfordsofsomerford.co.uk'])
+      expect(mail.from).to eql(['rob@purinkle.co.uk'])
       expect(mail.subject).to eql("Shipping confirmation for order #{order.id}")
       expect(page).to have_content('email sent')
     end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -17,7 +17,7 @@ describe Mailer do
       )
     end
 
-    let(:denise) { "denise@radfordsofsomerford.co.uk" }
+    let(:denise) { "rob@purinkle.co.uk" }
     let(:email) { 'alphonso.quigley@example.com' }
     let(:id) { 5 }
     let(:title) { "Order confirmation for order #{id}" }
@@ -54,7 +54,7 @@ describe Mailer do
     let(:title) { "Shipping confirmation for order #{id}" }
 
     it 'sends a mail from "noreply@example.com"' do
-      expect(subject.from).to eql(['denise@radfordsofsomerford.co.uk'])
+      expect(subject.from).to eql(['rob@purinkle.co.uk'])
     end
 
     it 'sends a mail to the order email' do

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -54,7 +54,7 @@ describe Mailer do
     let(:title) { "Shipping confirmation for order #{id}" }
 
     it 'sends a mail from "noreply@example.com"' do
-      expect(subject.from).to eql(['rob@purinkle.co.uk'])
+      expect(subject.from).to eql(["rob@purinkle.co.uk"])
     end
 
     it 'sends a mail to the order email' do


### PR DESCRIPTION
Before, we used Denise's email address as the sender of our email notifications. This email address had become inactive, and the application failed to send emails. We fixed the email sender's address to use an active email address.

[Trello][]

[trello]: https://trello.com/c/pUWLRlNl
