### PR TITLE
♻️ Reformat the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :staging, :production do
   gem "rack-timeout"
 end
 
-gem 'high_voltage'
-gem 'bourbon', '~> 5.0.0.beta.7'
-gem 'neat', '~> 2.0.0.beta.1'
-gem 'refills', group: [:development, :test]
+gem "bourbon", "~> 5.0.0.beta.7"
+gem "high_voltage"
+gem "neat", "~> 2.0.0.beta.1"
+gem "refills", group: %i[development test]


### PR DESCRIPTION
Before, we used single quotes in our Gemfile. This formatting differed from the standard used across the Ruby community. We reformatted the Gemfile to match the community standard.
