### PR TITLE
🛠️ Make the application use `factory_bot_rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   gem "bullet"
   gem "bundler-audit", ">= 0.5.0", require: false
   gem "dotenv-rails"
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,10 +113,10 @@ GEM
       railties (>= 3.2)
     erubis (2.7.0)
     execjs (2.9.1)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     ffi (1.16.3)
     flutie (2.2.0)
@@ -380,7 +380,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   flutie
   formulaic
   friendly_id

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,10 +1,10 @@
 if Rails.env.development? || Rails.env.test?
-  require "factory_girl"
+  require "factory_bot"
 
   namespace :dev do
     desc "Sample data for local development environment"
     task prime: "db:setup" do
-      include FactoryGirl::Syntax::Methods
+      include FactoryBot::Syntax::Methods
 
       create(:user, email: "admin@example.com", password: "password")
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -26,7 +26,7 @@ describe SessionsController do
 
     describe 'with valid email and password' do
       before (:each) do
-        @user = FactoryGirl.create(:user)
+        @user = FactoryBot.create(:user)
         @attr = { :email => @user.email, :password => @user.password }
       end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 include ActionDispatch::TestProcess
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :basket do
   end
 

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :order do
     address_line_1 '1 Test Street'
     address_city 'Testerton'

--- a/spec/features/layouts/header_spec.rb
+++ b/spec/features/layouts/header_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "application header" do
   let(:home_page) { HomePage.new }
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
   it "navigates to 'Your Basket'" do
     home_page.visit

--- a/spec/features/line_items/destroy_spec.rb
+++ b/spec/features/line_items/destroy_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module Features
   describe "destroy line item" do
-    let(:user) { FactoryGirl.create :user }
+    let(:user) { FactoryBot.create :user }
 
     before { create_product }
 

--- a/spec/features/orders/fulfil_order_spec.rb
+++ b/spec/features/orders/fulfil_order_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 module Features
   describe 'fulfil order' do
-    let(:order) { FactoryGirl.create(:order) }
+    let(:order) { FactoryBot.create(:order) }
     let(:order_page) { OrderPage.new(order) }
     let(:mail) { ActionMailer::Base.deliveries.last }
 

--- a/spec/features/suppliers/deleting_spec.rb
+++ b/spec/features/suppliers/deleting_spec.rb
@@ -4,7 +4,7 @@ module Features
   describe "deleting orders" do
     it "deletes existing order" do
       VCR.use_cassette("google maps") do
-        FactoryGirl.create(:supplier)
+        FactoryBot.create(:supplier)
       end
 
       sign_in

--- a/spec/features/suppliers/updating_spec.rb
+++ b/spec/features/suppliers/updating_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "updating suppliers" do
   it "successfully updates" do
     supplier = VCR.use_cassette("google maps") do
-      FactoryGirl.create(:supplier)
+      FactoryBot.create(:supplier)
     end
 
     sign_in
@@ -23,7 +23,7 @@ describe "updating suppliers" do
   context "when the attributes are invalid" do
     it "shows the 'Edit Supplier' page" do
       supplier = VCR.use_cassette("google maps") do
-        FactoryGirl.create(:supplier)
+        FactoryBot.create(:supplier)
       end
 
       sign_in

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end

--- a/spec/support/pages/new_product_page.rb
+++ b/spec/support/pages/new_product_page.rb
@@ -1,5 +1,5 @@
 class NewProductPage
-  include FactoryGirl::Syntax::Methods
+  include FactoryBot::Syntax::Methods
   include Capybara::DSL
   include Rails.application.routes.url_helpers
   include Formulaic::Dsl

--- a/spec/support/pages/new_session_page.rb
+++ b/spec/support/pages/new_session_page.rb
@@ -23,6 +23,6 @@ class NewSessionPage
   end
 
   def user
-    @user ||= FactoryGirl.create(:user)
+    @user ||= FactoryBot.create(:user)
   end
 end

--- a/spec/support/radfords.rb
+++ b/spec/support/radfords.rb
@@ -6,7 +6,7 @@ module RadfordsTestHelpers
   end
 
   def sign_in
-    user = FactoryGirl.create(:user)
+    user = FactoryBot.create(:user)
     page = SigninPage.new(user.email, user.password)
 
     page.visit


### PR DESCRIPTION
Before, we used `factory_girl_rails` to create test fixtures. thoughtbot renamed the gem `factory_bot_rails` and no longer updated this gem. We made the application use `factory_bot_rails` instead.
