### PR TITLE
🛠️ Make Skylight disable development warnings

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@ S3_HOST_NAME=s3-eu-west-1.amazonaws.com
 S3_REGION="eu-west-1"
 SECRET_KEY_BASE=development_secret
 SEGMENT_IO_KEY=development_segment
+SKYLIGHT_DISABLE_DEV_WARNING="true"
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com
 SMTP_PASSWORD=development_smtp_password


### PR DESCRIPTION
Before, Skylight would report the following warning in our development environment.

```text
WARN -- Skylight: [SKYLIGHT] [4.3.2] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
```

We wanted to reduce the noise in our logs to make errors more prominent. We made Skylight disable these development warnings by default.

[Trello](https://trello.com/c/Bij6kh2B)
