### PR TITLE
🐛 Fix the "Setup Review App" script

### DIFF
--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -9,7 +9,7 @@ if [ -z "$1" ]; then
   exit 64
 fi
 
-PARENT_APP_NAME=radfords-qa
+PARENT_APP_NAME=radfords-staging
 APP_NAME=radfords-qa-pr-$1
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 


### PR DESCRIPTION
Before, we changed the name of the Staging app on Heroku. We failed to reflect this change in our "Setup Review App" script, and the script failed every time. We fixed the script to use the Staging App's correct name.

[Trello](https://trello.com/c/TRyhJJ8J)
