### PR TITLE
🐛 Fix the Selenium deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ end
 
 group :test do
   gem "capybara-selenium"
-  gem "chromedriver-helper"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
@@ -60,6 +59,7 @@ group :test do
   gem "simplecov", require: false
   gem "timecop"
   gem "vcr"
+  gem "webdrivers"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (7.1.4)
     autoprefixer-rails (10.4.15.0)
       execjs (~> 2)
@@ -81,9 +79,6 @@ GEM
       capybara
       selenium-webdriver
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     climate_control (0.1.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -134,7 +129,6 @@ GEM
     high_voltage (3.0.0)
     honeybadger (5.3.0)
     i18n (0.8.6)
-    io-like (0.3.1)
     io-wait (0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.6.0)
@@ -355,6 +349,10 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
+    webdrivers (4.6.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -376,7 +374,6 @@ DEPENDENCIES
   bullet
   bundler-audit (>= 0.5.0)
   capybara-selenium
-  chromedriver-helper
   database_cleaner
   delayed_job_active_record
   dotenv-rails
@@ -422,6 +419,7 @@ DEPENDENCIES
   uglifier
   vcr
   web-console
+  webdrivers
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
Before when we ran the tests, we got the following warning.

```text
2023-12-04 06:55:52 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

We wanted to remove these messages to reduce the noise in our logs. We also needed to prepare ourselves for future changes. We fixed the warning by replacing the `chromedriver-helper` gem with `webdrivers`.

[Trello](https://trello.com/c/nhd6yNyv)
