### PR TITLE
🐛 Fix the Puma configuration

### DIFF
--- a/.env
+++ b/.env
@@ -22,4 +22,4 @@ SMTP_PASSWORD=development_smtp_password
 SMTP_USERNAME=development_smtp_username
 STRIPE_PUBLISHABLE_KEY=development_stripe_pk
 STRIPE_SECRET_KEY=development_stripe_sk
-WEB_CONCURRENCY=1
+WEB_CONCURRENCY=0


### PR DESCRIPTION
Before, when running Puma in the development environment, we saw many thread warnings. We want to reduce the amount of warnings to make actual errors more visible. We adjusted the Puma configuration after [a good chat][] with the NWRUG folks. We fixed the Puma configuration by pinching [some lines][] from Rails' default setup.

[Trello](https://trello.com/c/T9mRAcNx)

[a good chat]: https://groups.google.com/g/nwrug-members/c/WvXkeMFsr0E
[some lines]: https://github.com/rails/rails/blob/68eade83c87ae309191add6dfa4959d7d7e07464/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt#L28-L41
