### PR TITLE
🛠️ Make Skylight disabled by default

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,7 @@ S3_HOST_NAME=s3-eu-west-1.amazonaws.com
 S3_REGION="eu-west-1"
 SECRET_KEY_BASE=development_secret
 SEGMENT_IO_KEY=development_segment
+SKYLIGHT_ENABLED=false
 SKYLIGHT_DISABLE_DEV_WARNING="true"
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com


### PR DESCRIPTION
Before, we enabled Skylight for all environments. This caused the review apps to raise a warning because we have no config for that environment. We want to reduce any warnings to make actual errors more visible. We made Skylight disabled by default.

[Trello](https://trello.com/c/sg29AHa8)
