### PR TITLE
🛠️ Make Heroku use the most recent stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -50,5 +50,6 @@
     {
       "url": "heroku/ruby"
     }
-  ]
+  ],
+  "stack": "heroku-22"
 }


### PR DESCRIPTION
Before, we used Heroku's heroku-20 stack. This caused Heroku to raise the following warning.

```plaintext
remote: This app is using the Heroku-20 stack, however a newer stack is available.
remote: To upgrade to Heroku-22, see:
remote: https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack
```

We made Heroku use the most recent stack, as they recommended.

[Trello](https://trello.com/c/SggJH7Yp)
