### PR TITLE
♻️ Refactor the `bundler:audit` task

### DIFF
--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,12 +1,4 @@
 if Rails.env.development? || Rails.env.test?
-  require "bundler/audit/cli"
-
-  namespace :bundler do
-    desc "Updates the ruby-advisory-db and runs audit"
-    task :audit do
-      %w(update check).each do |command|
-        Bundler::Audit::CLI.start [command]
-      end
-    end
-  end
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
 end


### PR DESCRIPTION
Before, we had written a custom `bundler:audit` task. This duplicated the contents that existed in the gem. Having this duplication only created a development overhead. We refactored the task to import the behaviour from the gem.

[Trello](https://trello.com/c/D2jeNPi3)
