### PR TITLE
✨ Add a database backup to the review app setup

### DIFF
--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -11,6 +11,9 @@ fi
 
 PARENT_APP_NAME=radfords-staging
 APP_NAME=radfords-qa-pr-$1
+
+heroku pg:backups:capture --app $PARENT_APP_NAME
+
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME


### PR DESCRIPTION
Before, we used the previous `staging` backup when setting up our review apps. This backup may have contained stale data that would affect our testing. We added a database backup to the review app setup to ensure we used the latest data.

[Trello](https://trello.com/c/nXiee9Au)
