### PR TITLE
🛠️ Make timecop run in safe mode

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ if ENV.fetch("COVERAGE", false)
 end
 
 require "webmock/rspec"
+require "timecop"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
@@ -27,3 +28,6 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)
+
+# Only allow Timecop with block syntax
+Timecop.safe_mode = true


### PR DESCRIPTION
Before, we allowed developers to travel to a time with Timecop without setting a return time. This caused some tests to leak in unobvious ways. We made timecop run in safe mode to stop this from happening.

[Trello](https://trello.com/c/fJV4cjEp)
