### PR TITLE
🛠️ Make emails use a separate asset host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,5 +26,6 @@ Rails.application.configure do
   config.assets.quiet = true
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "localhost:9000" }
+  config.action_mailer.asset_host = {host: "localhost:9000"}
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,4 +37,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch("APPLICATION_HOST")
   }
+  config.action_mailer.asset_host = {
+    host: ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,5 +15,6 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
   config.assets.raise_runtime_errors = true
   config.action_mailer.default_url_options = { host: "www.example.com" }
+  config.action_mailer.asset_host = {host: "www.example.com"}
   config.active_job.queue_adapter = :inline
 end


### PR DESCRIPTION
Before, we used the same asset host for the application and our emails. This meant we had potential performance issues. We made emails use a separate asset host so we can use a CDN in the future.

[Trello](https://trello.com/c/4csOXq7a)
