### PR TITLE
🛠️ Make the application use SSL in Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,4 +40,5 @@ Rails.application.configure do
   config.action_mailer.asset_host = {
     host: ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
   }
+  config.force_ssl = true
 end


### PR DESCRIPTION
Before, we allowed our Production environments to run without SSL. This opened us up to potential security vulnerabilities. We made the application use SSL in Production to reduce this vulnerability.
