### PR TITLE
🛠️ Make the creation of `.git/safe` opt-in

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,8 +13,12 @@ bundle check || bundle install
 # Set up database and add any development seed data
 bin/rake dev:prime
 
-# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
-mkdir -p .git/safe
+if [ ! -d .git/safe ] && echo $PATH | grep .git/safe > /dev/null; then
+  echo "-----------------------------------------------------------------------"
+  echo
+  echo "-> When you trust this repo, remember to run: mkdir -p .git/safe"
+  echo
+fi
 
 # Only if this isn't CI
 # if [ -z "$CI" ]; then


### PR DESCRIPTION
Before, we created `.git/safe` as part of the setup. The idea behind this idea is that people choose whether the contents of `bin` are safe. Doing this for the person is antithetical. We made the creation of `.git/safe` opt-in.

[Trello](https://trello.com/c/kMEIi2U0)
