### PR TITLE
🛠️ Make Active Job attach individual log subscribers

### DIFF
--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,13 @@
+require "active_job/logging"
+
+ActiveSupport::Notifications.unsubscribe("enqueue.active_job")
+
+module ActiveJob
+  module Logging
+    class EnqueueLogSubscriber < LogSubscriber
+      define_method :enqueue, instance_method(:enqueue)
+    end
+  end
+end
+
+ActiveJob::Logging::EnqueueLogSubscriber.attach_to(:active_job)


### PR DESCRIPTION
Before, Active Job would use the same log subscriber for each job and its children. This would cause memory bloats on Heroku and bring the site down. We made Active Job attach individual subscribers for each job.

[Trello](https://trello.com/c/ne0mqx03)
