### PR TITLE
🗑️ Drop all vestigial staging references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "uglifier"
 
 group :development do
   gem "listen"
+  gem "rack-mini-profiler", require: false
   gem "spring", "~> 2.1"
   gem "spring-commands-rspec"
   gem "web-console"
@@ -45,10 +46,6 @@ group :development, :test do
   gem "rspec-rails", "~> 4.1"
 end
 
-group :development, :staging do
-  gem "rack-mini-profiler", require: false
-end
-
 group :test do
   gem "capybara-selenium"
   gem "database_cleaner"
@@ -62,7 +59,7 @@ group :test do
   gem "webmock"
 end
 
-group :staging, :production do
+group :production do
   gem "heroku-deflater"
   gem "rack-timeout"
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,5 +17,3 @@ production: &deploy
   pool: <%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url:  <%= ENV.fetch("DATABASE_URL", "") %>
-
-staging: *deploy

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,8 +7,5 @@ development:
 test:
   <<: *default
 
-staging:
-  <<: *default
-
 production:
   <<: *default


### PR DESCRIPTION
Before, we had a separate configuration for the Staging environment. In a previous change, we started using the same configuration as Production. We dropped all vestigial Staging references.

[Trello](https://trello.com/c/GyjDgf13)
