### PR TITLE
🛠️ Make Skylight ignore review apps

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,2 @@
+---
+disable_env_warning: true


### PR DESCRIPTION
Before, Skylight told us that we had not configured it for our review apps. The review apps run in a Production Rails environment, and Skylight didn't know. We wanted to remove the noise from our build logs to see more critical messages. We made Skylight ignore the review apps by adding a configuration file. We also added an environment variable, `SKYLIGHT_USER_CONFIG_PATH`, to point to the file.

[Trello]: https://trello.com/c/3aY40D6q