### PR TITLE
🛠️ Make the Puma startup message silent

### DIFF
--- a/spec/support/capybara_silence_puma.rb
+++ b/spec/support/capybara_silence_puma.rb
@@ -1,0 +1,1 @@
+Capybara.server = :puma, {Silent: true}

--- a/spec/support/capybara_silence_puma.rb
+++ b/spec/support/capybara_silence_puma.rb
@@ -1,1 +1,1 @@
-Capybara.server = :puma, {Silent: true}
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Before, when Capybara ran the first JavaScript spec, it printed this Puma message.

```plaintext
    Capybara starting Puma...
    * Version 3.12.1 , codename: Llamas in Pajamas
    * Min threads: 0, max threads: 4
    * Listening on tcp://127.0.0.1:62516
```

The message added unnecessary noise to our test suite. We configured Puma to be silent in our test suite to remove the message.

- [Trello](https://trello.com/c/We0GzY8N/)
