### PR TITLE
🛠️ Make Chromedriver headless

### DIFF
--- a/spec/support/chromedriver.rb
+++ b/spec/support/chromedriver.rb
@@ -5,14 +5,13 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) },
-  )
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.headless!
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities,
+    options: options,
   )
 end
 


### PR DESCRIPTION
Before, JavaScript specs opened Google Chrome to run their tests. There was no need to show Chrome, and it only distracted developers. We made Chromedriver run in a true headless mode.

[Trello](https://trello.com/c/cMl5k38u)