### PR TITLE
🛠️ Make ChromeDriver use a bigger window

### DIFF
--- a/spec/support/chromedriver.rb
+++ b/spec/support/chromedriver.rb
@@ -6,6 +6,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument "--window-size=1680,1050"
   options.headless!
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
Before, `save_and_open_screenshot` would only capture 75% of the screen. We needed to capture the entire screen to help us debug testing issues. We made ChromeDriver use a 1680 × 1050 window, the size of a 15" Retina MacBook Pro.

[Trello](https://trello.com/c/tskEPpEE)
