### PR TITLE
🗑️ Drop browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+defaults

--- a/browserslist
+++ b/browserslist
@@ -1,3 +1,0 @@
-Last 2 versions
-Explorer >= 11
-Android >= 4.4


### PR DESCRIPTION
Before, we used our own supported browsers configuration. Since installed Webpacker, this configuration is no longer necessary. Webpacker has its configuration. We dropped ours to avoid unnecessary duplication.

[Trello](https://trello.com/c/wmn1vpD0)
