### PR TITLE
✨ Add Listen watcher for Spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,9 @@ gem "title"
 gem "webpacker"
 
 group :development do
-  gem "listen"
   gem "rack-mini-profiler", require: false
-  gem "spring"
   gem "spring-commands-rspec"
+  gem "spring-watcher-listen"
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,9 +343,12 @@ GEM
       skylight-core (= 4.3.2)
     skylight-core (4.3.2)
       activesupport (>= 4.2.0)
-    spring (3.1.1)
+    spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-watcher-listen (2.0.1)
+      listen (>= 2.7, < 4.0)
+      spring (>= 1.2, < 3.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -425,7 +428,6 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  listen
   money-rails
   neat (~> 4.0.0)
   paperclip
@@ -445,8 +447,8 @@ DEPENDENCIES
   simple_form
   simplecov
   skylight
-  spring
   spring-commands-rspec
+  spring-watcher-listen
   sprockets (>= 3.0.0)
   stripe
   suspenders


### PR DESCRIPTION
Before, we included the `listen` and `spring` gems. As of Rails 5, [Rails includes the `Listen watcher for Spring` gem][]. This gem includes `listen` and `spring` as dependencies. It is also a good idea to match Rails definitions. We added the Listen watcher for Spring to align our gems.

[rails includes the `listen watcher for spring` gem]: https://github.com/rails/spring/commit/b614d94e83d863ffcb3eec06c6b2bb9250d5b5a5
