### PR TITLE
🗑️ Drop Neat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,5 +68,4 @@ end
 
 gem "bourbon", "~> 5.1.0"
 gem "high_voltage"
-gem "neat", "~> 4.0.0"
 gem "refills", group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,8 +204,6 @@ GEM
       money (~> 6.8.1)
       railties (>= 3.0)
     msgpack (1.7.2)
-    neat (4.0.0)
-      thor (~> 0.19)
     net-imap (0.2.2)
       digest
       net-protocol
@@ -429,7 +427,6 @@ DEPENDENCIES
   kaminari
   launchy
   money-rails
-  neat (~> 4.0.0)
   paperclip
   pg
   pry-byebug

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,6 @@
 @import "normalize.css/normalize.css";
 
 @import "bourbon";
-@import "neat";
 
 @import "base/base";
 @import "refills/flashes";

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -27,8 +27,10 @@ $green: #8fc243;
 .order-summary {
   @include border-bottom-radius($base-border-radius);
   @include border-top-radius($base-border-radius);
-  @include grid-column(6);
 
+  width: calc(50% - 30px);
+  float: left;
+  margin-left: 20px;
   border: $base-border;
 
   &:after,
@@ -38,8 +40,9 @@ $green: #8fc243;
   }
 
   .section {
-    @include grid-column(6);
-
+    width: calc(50% - 30px);
+    float: left;
+    margin-left: 20px;
     border-top: $base-border;
     margin-top: 0;
     padding: 1.5em;
@@ -183,7 +186,9 @@ $green: #8fc243;
 }
 
 .checkout {
-  @include grid-column(6);
+  width: calc(50% - 30px);
+  float: left;
+  margin-left: 20px;
 
   #{$all-text-inputs} {
     background: transparent;


### PR DESCRIPTION
Before, we used Neat as a lightweight and flexible Sass grid. Nowadays, we prefer to use modern CSS techniques like CSS Grid. We dropped Neat from our list of dependencies.

[Trello](https://trello.com/c/Zw04CzGx)
