### PR TITLE
🐛 Fix orders without a basket

### DIFF
--- a/app/models/empty_basket.rb
+++ b/app/models/empty_basket.rb
@@ -1,0 +1,9 @@
+class EmptyBasket
+  def line_items
+    LineItem.none
+  end
+
+  def to_partial_path
+    "empty_basket"
+  end
+end

--- a/app/models/find_basket.rb
+++ b/app/models/find_basket.rb
@@ -1,5 +1,5 @@
 class FindBasket
   def self.call(options)
-    Basket.where(options).first || MissingBasket.new
+    Basket.where(options).first || EmptyBasket.new
   end
 end

--- a/app/models/missing_basket.rb
+++ b/app/models/missing_basket.rb
@@ -2,8 +2,4 @@ class MissingBasket
   def line_items
     LineItem.none
   end
-
-  def to_partial_path
-    "empty_basket"
-  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -43,6 +43,10 @@ class Order < ActiveRecord::Base
     split_address.fetch(4, @address_county)
   end
 
+  def basket
+    super || MissingBasket.new
+  end
+
   def line_items
     basket.line_items
   end

--- a/spec/models/empty_basket_spec.rb
+++ b/spec/models/empty_basket_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe EmptyBasket do
+  describe "#line_items" do
+    it "is empty" do
+      empty_basket = EmptyBasket.new
+
+      line_items = empty_basket.line_items
+
+      expect(line_items).to be_empty
+    end
+  end
+
+  describe "#to_partial_path" do
+    it "is the partial to render the empty basket" do
+      empty_basket = EmptyBasket.new
+
+      partial_path = empty_basket.to_partial_path
+
+      expect(partial_path).to eq "empty_basket"
+    end
+  end
+end

--- a/spec/models/find_basket_spec.rb
+++ b/spec/models/find_basket_spec.rb
@@ -5,12 +5,12 @@ describe FindBasket do
     subject { FindBasket.call(options) }
 
     let(:basket) { double("Basket") }
-    let(:missing_basket) { double("MissingBasket") }
+    let(:empty_basket) { double("EmptyBasket") }
     let(:options) { { id: "1" } }
 
     before do
       allow(Basket).to receive(:where).with(options).and_return([basket])
-      allow(MissingBasket).to receive(:new).and_return(missing_basket)
+      allow(EmptyBasket).to receive(:new).and_return(empty_basket)
     end
 
     it "returns the found basket" do
@@ -21,7 +21,7 @@ describe FindBasket do
       let(:basket) { nil }
 
       it "returns a missing basket" do
-        expect(subject).to be(missing_basket)
+        expect(subject).to be(empty_basket)
       end
     end
   end

--- a/spec/models/missing_basket_spec.rb
+++ b/spec/models/missing_basket_spec.rb
@@ -14,10 +14,4 @@ describe MissingBasket do
       expect(basket.line_items).to be none
     end
   end
-
-  describe "#to_partial_path" do
-    it "returns 'empty_basket'" do
-      expect(basket.to_partial_path).to eql("empty_basket")
-    end
-  end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -128,6 +128,23 @@ describe Order do
     end
   end
 
+  describe "#basket" do
+    it "is the basket associated with the order" do
+      basket = build :basket
+      order = create :order, basket: basket
+
+      expect(order.basket).to be basket
+    end
+
+    context "when the order is missing a basket" do
+      it "is an empty basket" do
+        order = create :order, basket: nil
+
+        expect(order.basket).to have_attributes(line_items: [])
+      end
+    end
+  end
+
   describe "#line_items" do
     let(:basket) { double("Basket", line_items: items) }
     let(:items) { [] }


### PR DESCRIPTION
Before, the Orders page would throw an error when a customer placed an order without a basket. The seller could not see any valid orders and could not ship anything. We added a missing basket to ensure we showed all orders.

- Renamed `MissingBasket` to `EmptyBasket`

[Trello](https://trello.com/c/Ui3sIgc1)
