### PR TITLE
🔧 Make Heroku auto migrate on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
 worker: bundle exec rake jobs:work
+release: bin/auto_migrate

--- a/bin/auto_migrate
+++ b/bin/auto_migrate
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+if [ -n "$AUTO_MIGRATE_DB" ]; then
+  bundle exec rake db:migrate
+fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -8,5 +8,3 @@ branch="$(git symbolic-ref HEAD --short)"
 target="${1:-staging}"
 
 git push "$target" "$branch:master"
-heroku run rake db:migrate --exit-code --remote "$target"
-heroku restart --remote "$target"

--- a/bin/setup_review_app
+++ b/bin/setup_review_app
@@ -17,6 +17,5 @@ heroku pg:backups:capture --app $PARENT_APP_NAME
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME
-heroku run rake db:migrate --exit-code --app $APP_NAME
 heroku ps:scale worker=1 --app $APP_NAME
 heroku restart --app $APP_NAME


### PR DESCRIPTION
Before, we were migrating the database by hand in more than one location. This opened us up to potential inconsistencies. We made use of Heroku's release phase to always run the same migration script.

[Trello](https://trello.com/c/wQkswogw)
