### PR TITLE
🔧 Make RSpec check the Rails environment

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,10 @@
 ENV["RACK_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
-abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
+
+if Rails.env.production?
+  abort("The Rails environment is running in production mode!")
+end
 
 require "rspec/rails"
 


### PR DESCRIPTION
Before, we checked for `DATABASE_URL` to see if we were in Production. This approach was unreliable because we could set this variable in any environment. We made RSpec do an explicit check of the Rails environment instead.

[Trello](https://trello.com/c/V05Co9E4)
